### PR TITLE
Expose analyzer APIs on window for UI script access

### DIFF
--- a/index.html
+++ b/index.html
@@ -571,6 +571,12 @@
       if(Math.abs(c+b+o-100)>1)$('creditOther').value=Math.max(0,100-c-b);
     }
 
+    // Explicitly expose required APIs for external UI scripts.
+    window.calcScore = calcScore;
+    window.calculateSpiralStages = calculateSpiralStages;
+    window.tr = tr;
+    window.setLang = setLang;
+
     document.addEventListener('DOMContentLoaded',()=>{
       const sv=localStorage.getItem('bwa_data');
       if(sv){try{const d=JSON.parse(sv);const m={bn:'bankName',co:'country',pg:'profitGrowth',cp:'capital',di:'dividends',im:'interestMin',ix:'interestMax',ig:'incomeGrowth',pr:'povertyRate',gd:'gdpPerCapita',as:'avgSalary',cc:'creditConsumption',cb:'creditBusiness',co2:'creditOther'};Object.keys(d).forEach(k=>{if($(m[k])&&d[k]!==undefined)$(m[k]).value=d[k]})}catch(e){}}


### PR DESCRIPTION
### Motivation
- Ensure external UI scripts can access core analyzer functions/objects without `undefined` errors while preserving the existing plain-script global scope and business logic.

### Description
- Added explicit global exports in the inline script by assigning `window.calcScore = calcScore`, `window.calculateSpiralStages = calculateSpiralStages`, `window.tr = tr`, and `window.setLang = setLang` inside `index.html`.

### Testing
- Verified the export assignments are present in `index.html` by inspecting the file with line/print utilities (e.g. `nl`/`sed`) and confirmed the modified script block contains the four `window.*` assignments; no business logic was changed and no automated unit tests were required or run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09371be988324b29e230d872f3721)