### PR TITLE
Refactor JS: extract core scoring logic and isolate UI script

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,7 +207,8 @@
   </div>
 
     <script src="src/js/i18n.js"></script>
-  <script src="src/js/scoring.js"></script>
+    <script src="src/js/core/scoring.js"></script>
+    <script src="src/js/ui.js"></script>
 
 </body>
 </html>

--- a/src/js/core/scoring.js
+++ b/src/js/core/scoring.js
@@ -1,0 +1,73 @@
+(function () {
+  function normalizeAndCap(obj, max=40){
+    let total=Object.values(obj).reduce((a,b)=>a+b,0);
+    if(total===0)return;
+    for(let k in obj) obj[k]=(obj[k]/total)*100;
+    let changed=true, iter=0;
+    while(changed && iter<5){
+      changed=false;iter++;
+      let excess=0;
+      for(let k in obj){
+        if(obj[k]>max){excess+=obj[k]-max;obj[k]=max;changed=true;}
+      }
+      if(excess>0){
+        let keys=Object.keys(obj).filter(k=>obj[k]<max);
+        let subSum=keys.reduce((a,k)=>a+obj[k],0);
+        if(subSum>0){for(let k of keys)obj[k]+=excess*(obj[k]/subSum);}
+        else{let per=excess/Object.keys(obj).length;for(let k in obj)obj[k]+=per;}
+      }
+    }
+    let keys=Object.keys(obj), sum=0;
+    for(let k of keys){obj[k]=Math.round(obj[k]);sum+=obj[k];}
+    let diff=100-sum;
+    if(diff!==0){let target=keys.find(k => obj[k] + diff <= max); if(!target) target = keys[0]; obj[target] += diff;}
+  }
+
+  function calculateSpiralStages(data){
+    const pop={beige:0,purple:0,red:0,blue:0,orange:0,green:0,yellow:0,turquoise:0};
+    const bank={beige:0,purple:0,red:0,blue:0,orange:0,green:0,yellow:0,turquoise:0};
+
+    if (data.cc > 40) {
+      pop.beige = 40;
+      pop.purple = Math.min(15, 15 - (data.gd / 300));
+      pop.red = 5;
+      pop.blue = 25;
+      pop.orange = Math.min(5, data.gd / 500);
+      pop.green = Math.min(15, (data.pr * 0.4) + 2);
+      pop.yellow = 0;
+      pop.turquoise = 0;
+    } else {
+      pop.beige = Math.min(30, data.pr * 1.2);
+      pop.purple = Math.min(25, 30 - (data.gd / 200));
+      pop.red = Math.min(35, 20 + data.pr * 0.4);
+      pop.blue = 33;
+      pop.orange = Math.min(25, data.gd / 150);
+      pop.green = Math.min(20, data.pr * 0.5);
+      pop.yellow = Math.min(15, data.ig > 10 ? 12 : 5);
+      pop.turquoise = 0;
+    }
+
+    const profitGap = data.pg / Math.max(data.ig, 1);
+
+    bank.beige = data.cp < 10 ? Math.min(40, (10 - data.cp) * 10) : 0;
+    bank.purple = 0;
+    bank.red = Math.min(40, 20 + (profitGap > 5 ? 15 : profitGap * 3) + (data.cc > 40 ? 5 : 0));
+    bank.blue = Math.min(30, 20);
+    bank.orange = Math.min(30, data.cb * 1 + (profitGap < 3 ? 10 : 0));
+    bank.green = Math.max(0, Math.min(20, 100 - data.di - (data.cc > 40 ? 15 : 0)));
+    bank.yellow = Math.min(15, data.cb > 25 ? 10 : 3);
+    bank.turquoise = 0;
+
+    normalizeAndCap(pop);
+    normalizeAndCap(bank);
+    return{population:pop,bank};
+  }
+
+  function calcScore(d){
+    const gap=d.pg/Math.max(d.ig,0.1),gf=Math.max(0,100-gap*3),cf=100-d.cc,pf=100-d.pr,ar=(d.im+d.ix)/2,inf=Math.max(0,100-(ar-10)*2),df=100-d.di*0.5;
+    return Math.max(0,Math.min(100,Math.round(gf*0.3+cf*0.25+pf*0.2+inf*0.15+df*0.1)));
+  }
+
+  window.calcScore = calcScore;
+  window.calculateSpiralStages = calculateSpiralStages;
+})();

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -45,70 +45,6 @@
     $('resultsTitle').scrollIntoView({behavior:'smooth',block:'start'});
   }
 
-  function normalizeAndCap(obj, max=40){
-    let total=Object.values(obj).reduce((a,b)=>a+b,0);
-    if(total===0)return;
-    for(let k in obj) obj[k]=(obj[k]/total)*100;
-    let changed=true, iter=0;
-    while(changed && iter<5){
-      changed=false;iter++;
-      let excess=0;
-      for(let k in obj){
-        if(obj[k]>max){excess+=obj[k]-max;obj[k]=max;changed=true;}
-      }
-      if(excess>0){
-        let keys=Object.keys(obj).filter(k=>obj[k]<max);
-        let subSum=keys.reduce((a,k)=>a+obj[k],0);
-        if(subSum>0){for(let k of keys)obj[k]+=excess*(obj[k]/subSum);}
-        else{let per=excess/Object.keys(obj).length;for(let k in obj)obj[k]+=per;}
-      }
-    }
-    let keys=Object.keys(obj), sum=0;
-    for(let k of keys){obj[k]=Math.round(obj[k]);sum+=obj[k];}
-    let diff=100-sum;
-    if(diff!==0){let target=keys.find(k => obj[k] + diff <= max); if(!target) target = keys[0]; obj[target] += diff;}
-  }
-
-  function calculateSpiralStages(data){
-    const pop={beige:0,purple:0,red:0,blue:0,orange:0,green:0,yellow:0,turquoise:0};
-    const bank={beige:0,purple:0,red:0,blue:0,orange:0,green:0,yellow:0,turquoise:0};
-
-    if (data.cc > 40) {
-      pop.beige = 40;
-      pop.purple = Math.min(15, 15 - (data.gd / 300));
-      pop.red = 5;
-      pop.blue = 25;
-      pop.orange = Math.min(5, data.gd / 500);
-      pop.green = Math.min(15, (data.pr * 0.4) + 2);
-      pop.yellow = 0;
-      pop.turquoise = 0;
-    } else {
-      pop.beige = Math.min(30, data.pr * 1.2);
-      pop.purple = Math.min(25, 30 - (data.gd / 200));
-      pop.red = Math.min(35, 20 + data.pr * 0.4);
-      pop.blue = 33;
-      pop.orange = Math.min(25, data.gd / 150);
-      pop.green = Math.min(20, data.pr * 0.5);
-      pop.yellow = Math.min(15, data.ig > 10 ? 12 : 5);
-      pop.turquoise = 0;
-    }
-
-    const profitGap = data.pg / Math.max(data.ig, 1);
-
-    bank.beige = data.cp < 10 ? Math.min(40, (10 - data.cp) * 10) : 0;
-    bank.purple = 0;
-    bank.red = Math.min(40, 20 + (profitGap > 5 ? 15 : profitGap * 3) + (data.cc > 40 ? 5 : 0));
-    bank.blue = Math.min(30, 20);
-    bank.orange = Math.min(30, data.cb * 1 + (profitGap < 3 ? 10 : 0));
-    bank.green = Math.max(0, Math.min(20, 100 - data.di - (data.cc > 40 ? 15 : 0)));
-    bank.yellow = Math.min(15, data.cb > 25 ? 10 : 3);
-    bank.turquoise = 0;
-
-    normalizeAndCap(pop);
-    normalizeAndCap(bank);
-    return{population:pop,bank};
-  }
-
   function renderDetailedAnalysis(data, population, bank){
     const stages=['beige','purple','red','blue','orange','green','yellow','turquoise'];
     const icons={beige:'🟤',purple:'🟣',red:'🔴',blue:'🔵',orange:'🟠',green:'🟢',yellow:'🟡',turquoise:'💎'};
@@ -212,11 +148,11 @@
       window.chart=new Chart(ctx,{type:'doughnut',data:{labels:[window.i18n.tr[window.i18n.lang].cons,window.i18n.tr[window.i18n.lang].bus,window.i18n.tr[window.i18n.lang].other],datasets:[{data:[d.cc,d.cb,d.co2],backgroundColor:['#dc2626','#16a34a','#64748b'],borderWidth:0,spacing:2}]},options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{position:'bottom',labels:{usePointStyle:true,padding:20,font:{size:11}}},tooltip:{callbacks:{label:c=>c.label+': '+c.parsed+'%'}}},cutout:'65%'}});
     }else{window.chart.data.labels=[window.i18n.tr[window.i18n.lang].cons,window.i18n.tr[window.i18n.lang].bus,window.i18n.tr[window.i18n.lang].other];window.chart.data.datasets[0].data=[d.cc,d.cb,d.co2];window.chart.update();}
 
-    const spiral=calculateSpiralStages(d);
+    const spiral=window.calculateSpiralStages(d);
     initSpiralChart(spiral.population,spiral.bank);
     renderDetailedAnalysis(d,spiral.population,spiral.bank);
 
-    const sc=calcScore(d);
+    const sc=window.calcScore(d);
     $('scoreVal').textContent=sc+'/100';
     const sf=$('scoreFill');sf.style.width=sc+'%';
     sf.style.background=sc<40?'var(--d)':sc<70?'var(--w)':'var(--s)';
@@ -225,11 +161,6 @@
     if(gap>5&&d.cc>40){wb.style.background='#fef2f2';wb.style.color='var(--d)';wt.textContent=window.i18n.lang==='ru'?`Прибыль банка растёт в ${Math.round(gap)} раз быстрее доходов населения. Высокая доля потребительских кредитов (${d.cc}%) указывает на кредитование бедности, а не развития.`:`Bank profit grows ${Math.round(gap)}x faster than population income. High share of consumption loans (${d.cc}%) indicates lending to poverty, not development.`;}
     else if(sc>=70){wb.style.background='#dcfce7';wb.style.color='#166534';wt.textContent=window.i18n.lang==='ru'?`✅ Банк показывает сбалансированную модель: умеренные ставки, фокус на бизнес-кредитование и рост доходов населения.`:`✅ Bank shows balanced model: moderate rates, focus on business lending, and population income growth.`;}
     else{wb.style.background='#fef3c7';wb.style.color='#92400e';wt.textContent=window.i18n.lang==='ru'?`⚠️ Требуется мониторинг: отдельные показатели указывают на риски долговой нагрузки.`:`⚠️ Monitor needed: some indicators suggest debt burden risks.`;}
-  }
-
-  function calcScore(d){
-    const gap=d.pg/Math.max(d.ig,0.1),gf=Math.max(0,100-gap*3),cf=100-d.cc,pf=100-d.pr,ar=(d.im+d.ix)/2,inf=Math.max(0,100-(ar-10)*2),df=100-d.di*0.5;
-    return Math.max(0,Math.min(100,Math.round(gf*0.3+cf*0.25+pf*0.2+inf*0.15+df*0.1)));
   }
 
   function fixCredit(){
@@ -246,8 +177,6 @@
     ['creditConsumption','creditBusiness','creditOther'].forEach(id=>$(id).addEventListener('change',fixCredit));
   });
 
-  window.calcScore = calcScore;
-  window.calculateSpiralStages = calculateSpiralStages;
   window.refresh = refresh;
   window.loadEx = loadEx;
   window.doAnalyze = doAnalyze;


### PR DESCRIPTION
### Motivation
- Separate pure calculation logic from DOM/UI so business rules are easier to reason about and reuse while keeping runtime behavior identical.

### Description
- Moved pure scoring and spiral-stage calculation functions (`normalizeAndCap`, `calculateSpiralStages`, `calcScore`) into `src/js/core/scoring.js` and exposed `window.calcScore` and `window.calculateSpiralStages`.
- Kept all UI/controller and rendering code in `src/js/ui.js` and exposed `window.doAnalyze`, `window.loadEx`, and `window.refresh` to preserve the global API.
- Updated `index.html` script include order to load `src/js/i18n.js` then `src/js/core/scoring.js` then `src/js/ui.js`, and preserved plain script global scope and all original formulas and UI behavior.

### Testing
- Ran `node --check src/js/core/scoring.js` which succeeded.
- Ran `node --check src/js/ui.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e2275d7083249cb9a936079f4768)