### PR TITLE
Add mismatch detection layer and surface results in UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,10 @@
         <div id="warnBox" style="margin-top:16px;padding:10px;background:#fef2f2;border-radius:8px;color:var(--d)">
           <strong id="tWarn">⚠️ Предупреждение:</strong> <span id="warnText">Прибыль банка растёт в 16 раз быстрее доходов населения. Высокая доля потребительских кредитов указывает на кредитование бедности, а не развития.</span>
         </div>
+        <div id="mismatchBox" style="margin-top:12px;padding:10px;background:#f8fafc;border-radius:8px;border:1px solid var(--b);text-align:left">
+          <strong>Mismatch score:</strong> <span id="mismatchVal">0.00</span>
+          <div id="mismatchText" style="margin-top:6px;font-size:.85rem;color:var(--tm)"></div>
+        </div>
       </div>
 
       <div class="grid" style="margin-top:16px">
@@ -208,6 +212,7 @@
 
     <script src="src/js/i18n.js"></script>
     <script src="src/js/core/scoring.js"></script>
+    <script src="src/js/core/mismatch.js"></script>
     <script src="src/js/ui.js"></script>
 
 </body>

--- a/src/js/core/mismatch.js
+++ b/src/js/core/mismatch.js
@@ -1,0 +1,72 @@
+(function () {
+  const STAGES = ['beige', 'purple', 'red', 'blue', 'orange', 'green', 'yellow', 'turquoise'];
+
+  function dominantStage(map) {
+    return STAGES.reduce((maxStage, stage) => (map[stage] > map[maxStage] ? stage : maxStage), STAGES[0]);
+  }
+
+  function parseEsgSignal(esgText) {
+    if (!esgText || typeof esgText !== 'string') {
+      return { hasInput: false, claimsHighEsg: false };
+    }
+
+    const text = esgText.toLowerCase();
+    const keywords = [
+      'esg', 'sustainable', 'sustainability', 'green finance', 'inclusive', 'impact',
+      'ответствен', 'устойчив', 'зел', 'социальн', 'инклюзив'
+    ];
+
+    return {
+      hasInput: true,
+      claimsHighEsg: keywords.some((word) => text.includes(word))
+    };
+  }
+
+  function clamp01(value) {
+    return Math.max(0, Math.min(1, value));
+  }
+
+  function calculateMismatch(scoringOutput, esgText) {
+    const safeOutput = scoringOutput || {};
+    const score = typeof safeOutput.score === 'number' ? safeOutput.score : 0;
+    const spiral = safeOutput.spiral || {};
+    const population = spiral.population || {};
+    const bank = spiral.bank || {};
+
+    const popDominant = dominantStage(population);
+    const bankDominant = dominantStage(bank);
+
+    const redGap = Math.max(0, (bank.red || 0) - (population.red || 0));
+    const greenGap = Math.max(0, (population.green || 0) - (bank.green || 0));
+    const structuralGap = STAGES.reduce((sum, stage) => sum + Math.abs((bank[stage] || 0) - (population[stage] || 0)), 0) / 2;
+
+    const esgSignal = parseEsgSignal(esgText);
+    const claimsPenalty = esgSignal.claimsHighEsg && (bank.red || 0) >= 25 && (bank.green || 0) <= 10 ? 0.2 : 0;
+    const scorePenalty = (100 - score) / 100;
+
+    const mismatchScore = clamp01(
+      (redGap / 40) * 0.35 +
+      (greenGap / 40) * 0.25 +
+      (structuralGap / 100) * 0.25 +
+      scorePenalty * 0.15 +
+      claimsPenalty
+    );
+
+    let severity;
+    if (mismatchScore >= 0.67) severity = 'high';
+    else if (mismatchScore >= 0.34) severity = 'medium';
+    else severity = 'low';
+
+    const mismatchDescription = {
+      en: `Mismatch is ${severity}: bank dominant stage is ${bankDominant} (${bank[bankDominant] || 0}%) while population is ${popDominant} (${population[popDominant] || 0}%). Red pressure gap: ${Math.round(redGap)}pp, empathy gap: ${Math.round(greenGap)}pp.${esgSignal.hasInput ? (esgSignal.claimsHighEsg ? ' ESG messaging detected and checked against behavior.' : ' ESG text provided but no strong sustainability claim detected.') : ''}`,
+      ru: `Несоответствие ${severity === 'high' ? 'высокое' : severity === 'medium' ? 'среднее' : 'низкое'}: доминирующая стадия банка — ${bankDominant} (${bank[bankDominant] || 0}%), населения — ${popDominant} (${population[popDominant] || 0}%). Разрыв по Red: ${Math.round(redGap)} п.п., по эмпатии (Green): ${Math.round(greenGap)} п.п.${esgSignal.hasInput ? (esgSignal.claimsHighEsg ? ' Обнаружены ESG-заявления и сопоставлены с поведением.' : ' ESG-текст есть, но сильных заявлений об устойчивости не найдено.') : ''}`
+    };
+
+    return {
+      mismatchScore,
+      mismatchDescription
+    };
+  }
+
+  window.calculateMismatch = calculateMismatch;
+})();

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -156,6 +156,11 @@
     $('scoreVal').textContent=sc+'/100';
     const sf=$('scoreFill');sf.style.width=sc+'%';
     sf.style.background=sc<40?'var(--d)':sc<70?'var(--w)':'var(--s)';
+
+    const esgInput = $('esgText') ? $('esgText').value : '';
+    const mismatch = window.calculateMismatch({ score: sc, spiral }, esgInput);
+    $('mismatchVal').textContent = mismatch.mismatchScore.toFixed(2);
+    $('mismatchText').textContent = mismatch.mismatchDescription[window.i18n.lang] || mismatch.mismatchDescription.en;
     const gap=d.pg/Math.max(d.ig,0.1);
     const wb=$('warnBox'),wt=$('warnText');
     if(gap>5&&d.cc>40){wb.style.background='#fef2f2';wb.style.color='var(--d)';wt.textContent=window.i18n.lang==='ru'?`Прибыль банка растёт в ${Math.round(gap)} раз быстрее доходов населения. Высокая доля потребительских кредитов (${d.cc}%) указывает на кредитование бедности, а не развития.`:`Bank profit grows ${Math.round(gap)}x faster than population income. High share of consumption loans (${d.cc}%) indicates lending to poverty, not development.`;}


### PR DESCRIPTION
### Motivation

- Detect divergence between a bank's declared/communicated ESG claims and its actual behavior as inferred from existing scoring/spiral outputs.  
- Surface a compact, easy-to-interpret mismatch metric alongside the existing score without changing scoring formulas or UI layout.  

### Description

- Added a standalone mismatch module at `src/js/core/mismatch.js` that exposes `window.calculateMismatch` and computes a `mismatchScore` (0–1) plus bilingual `mismatchDescription`.  
- The module derives signals from the spiral outputs (population vs bank stages), the welfare `score`, and optional ESG text, and combines red/green gaps, structural divergence, and claim-vs-behavior penalties into the score.  
- Integrated the call into `src/js/ui.js` immediately after `calcScore`/`calculateSpiralStages` and writes results into the existing results card using a small `#mismatchBox` block added to `index.html`; no changes to score logic, layout, global script scope, or module system were made.  
- Supports optional ESG free text input (reads `#esgText` if present) but degrades safely when not provided.

### Testing

- Performed static syntax checks with `node --check` on `src/js/core/mismatch.js`, `src/js/ui.js`, and `src/js/core/scoring.js`, which completed successfully.  
- Confirmed the new script is loaded before `ui.js` and that `window.calculateMismatch` is callable from the UI flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e4de1fbc83249c0d28c5bcb05793)