### PR TITLE
Add toggleable debug logs for ESG mapping and mismatch calculations

### DIFF
--- a/src/js/core/mismatch.js
+++ b/src/js/core/mismatch.js
@@ -1,5 +1,25 @@
 (function () {
   const STAGES = ['beige', 'purple', 'red', 'blue', 'orange', 'green', 'yellow', 'turquoise'];
+  const DEBUG_FLAG_KEY = '__BWA_DEBUG__';
+
+  function isDebugEnabled() {
+    if (typeof window === 'undefined') return false;
+    if (window[DEBUG_FLAG_KEY] === true) return true;
+    try {
+      return window.localStorage && window.localStorage.getItem(DEBUG_FLAG_KEY) === 'true';
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function debugLog(message, payload) {
+    if (!isDebugEnabled()) return;
+    if (typeof payload === 'undefined') {
+      console.log('[mismatch]', message);
+      return;
+    }
+    console.log('[mismatch]', message, payload);
+  }
 
   function dominantStage(map) {
     return STAGES.reduce((maxStage, stage) => (map[stage] > map[maxStage] ? stage : maxStage), STAGES[0]);
@@ -44,6 +64,7 @@
     const esgSignal = parseEsgSignal(esgText);
     const claimsPenalty = esgSignal.claimsHighEsg && (bank.red || 0) >= 25 && (bank.green || 0) <= 10 ? 0.2 : 0;
     const scorePenalty = (100 - score) / 100;
+    debugLog('penalties', { claimsPenalty, scorePenalty: Number(scorePenalty.toFixed(3)) });
 
     const mismatchScore = clamp01(
       (redGap / 40) * 0.35 +
@@ -52,6 +73,19 @@
       scorePenalty * 0.15 +
       claimsPenalty
     );
+    debugLog('stage scores', {
+      populationDominant: popDominant,
+      bankDominant,
+      redGap: Number(redGap.toFixed(3)),
+      greenGap: Number(greenGap.toFixed(3)),
+      structuralGap: Number(structuralGap.toFixed(3)),
+      mismatchScore: Number(mismatchScore.toFixed(3))
+    });
+    debugLog('confidence calculation', {
+      esgConfidence: Number((esgSignal.confidence || 0).toFixed(3)),
+      claimsHighEsg: esgSignal.claimsHighEsg,
+      primaryStage: esgSignal.primaryStage || null
+    });
 
     let severity;
     if (mismatchScore >= 0.67) severity = 'high';

--- a/src/js/core/valueMapping.js
+++ b/src/js/core/valueMapping.js
@@ -1,4 +1,25 @@
 (function () {
+  const DEBUG_FLAG_KEY = '__BWA_DEBUG__';
+
+  function isDebugEnabled() {
+    if (typeof window === 'undefined') return false;
+    if (window[DEBUG_FLAG_KEY] === true) return true;
+    try {
+      return window.localStorage && window.localStorage.getItem(DEBUG_FLAG_KEY) === 'true';
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function debugLog(message, payload) {
+    if (!isDebugEnabled()) return;
+    if (typeof payload === 'undefined') {
+      console.log('[valueMapping]', message);
+      return;
+    }
+    console.log('[valueMapping]', message, payload);
+  }
+
   const STAGE_EXPECTATIONS = {
     beige: {
       en: 'Preserve minimum stability and continuity of essential banking access.',
@@ -155,15 +176,18 @@
         const frequency = countOccurrences(text, entry.term);
         if (frequency > 0) {
           stageFrequencies[stage] = (stageFrequencies[stage] || 0) + frequency;
+          debugLog('keyword match', { stage, term: entry.term, frequency, weight: entry.weight });
         }
         return sum + (frequency * entry.weight);
       }, 0);
 
       stageScores[stage] = Number(weighted.toFixed(3));
+      debugLog('stage score', { stage, score: stageScores[stage], frequency: stageFrequencies[stage] || 0 });
     });
 
     const buzzwordFrequency = GENERIC_ESG_BUZZWORDS.reduce((sum, term) => sum + countOccurrences(text, term), 0);
     const buzzwordPenalty = Math.min(0.65, buzzwordFrequency * 0.08);
+    debugLog('penalty', { type: 'buzzword', buzzwordFrequency, buzzwordPenalty: Number(buzzwordPenalty.toFixed(3)) });
 
     const rankedStages = STAGES
       .map((stage) => ({ stage, score: stageScores[stage] }))
@@ -179,6 +203,15 @@
     const separation = topScore > 0 ? (topScore - secondScore) / topScore : 0;
     const evidence = 1 - Math.exp(-totalWeightedSignal / 6);
     const confidence = Math.max(0, Math.min(1, (0.45 * separation + 0.55 * evidence) - buzzwordPenalty));
+    debugLog('confidence calculation', {
+      topScore,
+      secondScore,
+      totalWeightedSignal: Number(totalWeightedSignal.toFixed(3)),
+      separation: Number(separation.toFixed(3)),
+      evidence: Number(evidence.toFixed(3)),
+      buzzwordPenalty: Number(buzzwordPenalty.toFixed(3)),
+      confidence: Number(confidence.toFixed(3))
+    });
 
     return {
       hasInput: true,
@@ -194,4 +227,16 @@
   }
 
   window.mapValuesToBehavior = mapValuesToBehavior;
+  window.setBwaDebug = function setBwaDebug(enabled) {
+    const normalized = !!enabled;
+    window[DEBUG_FLAG_KEY] = normalized;
+    try {
+      if (window.localStorage) {
+        window.localStorage.setItem(DEBUG_FLAG_KEY, String(normalized));
+      }
+    } catch (error) {
+      // no-op when storage is unavailable
+    }
+    return normalized;
+  };
 })();


### PR DESCRIPTION
### Motivation
- Make ESG mapping and mismatch calculations transparent for validation and troubleshooting by adding opt-in runtime diagnostics without modifying scoring behavior or UI.

### Description
- Added a runtime debug flag key `__BWA_DEBUG__` and `isDebugEnabled`/`debugLog` helpers to `src/js/core/valueMapping.js` and `src/js/core/mismatch.js` to gate logs.
- Added a small helper `window.setBwaDebug(enabled)` which toggles `window.__BWA_DEBUG__` and persists the setting to `localStorage` so logs can be enabled/disabled at runtime.
- Emitted targeted debug logs in `valueMapping` for keyword matches, per-stage scores, buzzword penalty, and the confidence calculation inputs/outputs, and in `mismatch` for penalties, gap/stage score components, and the ESG confidence context.
- Preserved constraints: no scoring formulas were changed, no UI layout files were modified, and no ES module conversion was introduced.

### Testing
- Ran `npm test -- --watch=false`, which failed because `package.json` is not present in the repository root (automated tests could not be executed).
- No other automated test suites were available or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1cbc052508324b42d954b597b5c5a)