### PR TITLE
Add explanation layer for mismatch results and surface risk/driver in UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,7 +175,9 @@
           <strong id="tWarn">⚠️ Предупреждение:</strong> <span id="warnText">Прибыль банка растёт в 16 раз быстрее доходов населения. Высокая доля потребительских кредитов указывает на кредитование бедности, а не развития.</span>
         </div>
         <div id="mismatchBox" style="margin-top:12px;padding:10px;background:#f8fafc;border-radius:8px;border:1px solid var(--b);text-align:left">
-          <strong>Mismatch score:</strong> <span id="mismatchVal">0.00</span>
+          <div><strong id="mismatchScoreLabel">Mismatch score:</strong> <span id="mismatchVal">0.00</span></div>
+          <div style="margin-top:4px;"><strong id="mismatchRiskLabel">Risk level:</strong> <span id="mismatchRiskLevel">-</span></div>
+          <div style="margin-top:4px;"><strong id="mismatchDriverLabel">Primary driver:</strong> <span id="mismatchDriver">-</span></div>
           <div id="mismatchText" style="margin-top:6px;font-size:.85rem;color:var(--tm)"></div>
         </div>
       </div>

--- a/src/js/core/mismatch.js
+++ b/src/js/core/mismatch.js
@@ -92,6 +92,58 @@
     else if (mismatchScore >= 0.34) severity = 'medium';
     else severity = 'low';
 
+    function inferPrimaryDriver() {
+      const scoreFactors = {
+        redPressure: (redGap / 40) * 0.35,
+        empathyGap: (greenGap / 40) * 0.25,
+        stageMismatch: (structuralGap / 100) * 0.25,
+        welfareScorePenalty: scorePenalty * 0.15,
+        esgClaimMismatch: claimsPenalty
+      };
+      const topFactor = Object.entries(scoreFactors).reduce((max, item) => (item[1] > max[1] ? item : max), ['redPressure', 0]);
+      return topFactor[0];
+    }
+
+    function buildExplanationText(primaryDriver) {
+      const confidencePct = Math.round((esgSignal.confidence || 0) * 100);
+      const labels = {
+        redPressure: {
+          en: 'Bank pressure (Red stage) is much higher than social resistance.',
+          ru: 'Давление банка (стадия Red) значительно выше сопротивления общества.'
+        },
+        empathyGap: {
+          en: 'Population relies on mutual aid more than the bank shows empathy.',
+          ru: 'Население сильнее опирается на взаимопомощь, чем банк проявляет эмпатию.'
+        },
+        stageMismatch: {
+          en: 'Bank and population value-stage profiles are structurally misaligned.',
+          ru: 'Профили ценностных стадий банка и населения структурно не совпадают.'
+        },
+        welfareScorePenalty: {
+          en: 'Core welfare indicators reduce trust in inclusive impact.',
+          ru: 'Базовые показатели благосостояния снижают доверие к инклюзивному эффекту.'
+        },
+        esgClaimMismatch: {
+          en: 'ESG claims conflict with observed high-pressure/low-empathy behavior.',
+          ru: 'Заявления ESG конфликтуют с наблюдаемым высоким давлением и низкой эмпатией.'
+        }
+      };
+
+      const riskText = severity === 'high'
+        ? { en: 'High risk of extractive mismatch.', ru: 'Высокий риск экстрактивного несоответствия.' }
+        : severity === 'medium'
+          ? { en: 'Moderate misalignment risk that needs monitoring.', ru: 'Умеренный риск несоответствия, требуется мониторинг.' }
+          : { en: 'Low mismatch risk under current inputs.', ru: 'Низкий риск несоответствия при текущих данных.' };
+
+      return {
+        en: `${riskText.en} Main reason: ${labels[primaryDriver].en} Mismatch score ${mismatchScore.toFixed(2)}. ESG confidence ${confidencePct}%. Dominant stages: bank ${bankDominant}, population ${popDominant}.`,
+        ru: `${riskText.ru} Главная причина: ${labels[primaryDriver].ru} Индекс несоответствия ${mismatchScore.toFixed(2)}. Уверенность ESG ${confidencePct}%. Доминирующие стадии: банк ${bankDominant}, население ${popDominant}.`
+      };
+    }
+
+    const primaryDriver = inferPrimaryDriver();
+    const explanationText = buildExplanationText(primaryDriver);
+
     const mismatchDescription = {
       en: `Mismatch is ${severity}: bank dominant stage is ${bankDominant} (${bank[bankDominant] || 0}%) while population is ${popDominant} (${population[popDominant] || 0}%). Red pressure gap: ${Math.round(redGap)}pp, empathy gap: ${Math.round(greenGap)}pp.${esgSignal.hasInput ? ` ESG mapping confidence: ${Math.round((esgSignal.confidence || 0) * 100)}%.` : ''}${esgSignal.hasInput ? (esgSignal.claimsHighEsg ? ` ESG value stages detected: ${esgSignal.detectedStages.join(', ') || 'none'}. Expected behavior: ${esgSignal.primaryStage ? ((esgSignal.stageExpectations[esgSignal.primaryStage] || {}).en || 'not defined') : 'not defined'}` : ' ESG text provided but no strong sustainability claim detected.') : ''}`,
       ru: `Несоответствие ${severity === 'high' ? 'высокое' : severity === 'medium' ? 'среднее' : 'низкое'}: доминирующая стадия банка — ${bankDominant} (${bank[bankDominant] || 0}%), населения — ${popDominant} (${population[popDominant] || 0}%). Разрыв по Red: ${Math.round(redGap)} п.п., по эмпатии (Green): ${Math.round(greenGap)} п.п.${esgSignal.hasInput ? ` Уверенность ESG-мэппинга: ${Math.round((esgSignal.confidence || 0) * 100)}%.` : ''}${esgSignal.hasInput ? (esgSignal.claimsHighEsg ? ` Обнаружены ценностные стадии ESG: ${esgSignal.detectedStages.join(', ') || 'нет'}. Ожидаемое поведение: ${esgSignal.primaryStage ? ((esgSignal.stageExpectations[esgSignal.primaryStage] || {}).ru || 'не определено') : 'не определено'}` : ' ESG-текст есть, но сильных заявлений об устойчивости не найдено.') : ''}`
@@ -100,6 +152,9 @@
     return {
       mismatchScore,
       esgConfidence: esgSignal.confidence || 0,
+      riskLevel: severity,
+      primaryDriver,
+      explanationText,
       mismatchDescription
     };
   }

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -33,7 +33,10 @@
       bankText:"КУЛЬТУРА БАНКА",
       gapTitle:"⚠️ АНАЛИЗ СПИРАЛЬНОГО РАЗРЫВА:",
       recTitle:"💡 РЕКОМЕНДАЦИЯ:",
-      stageMeaning:{beige:"Выживание",purple:"Традиции/Семья",red:"Неравенство/Бунт",blue:"Порядок/Дисциплина",orange:"Достижение/Средний класс",green:"Эмпатия/Взаимопомощь",yellow:"Гибкость/Адаптация",turquoise:"Холизм/Глобальность"}
+      stageMeaning:{beige:"Выживание",purple:"Традиции/Семья",red:"Неравенство/Бунт",blue:"Порядок/Дисциплина",orange:"Достижение/Средний класс",green:"Эмпатия/Взаимопомощь",yellow:"Гибкость/Адаптация",turquoise:"Холизм/Глобальность"},
+      mismatchScoreLabel:"Mismatch индекс:", mismatchRiskLabel:"Уровень риска:", mismatchDriverLabel:"Главный драйвер:",
+      riskLevels:{low:"низкий",medium:"средний",high:"высокий"},
+      driverLabels:{redPressure:"Давление Red",empathyGap:"Разрыв эмпатии",stageMismatch:"Структурный разрыв стадий",welfareScorePenalty:"Слабый welfare score",esgClaimMismatch:"Разрыв ESG-заявлений"}
     },
     en: {
       app:"Bank Welfare Analyzer",inpTitle:"Bank Input Data",btnAnalyze:"🚀 Analyze",
@@ -68,7 +71,10 @@
       bankText:"BANK CULTURE",
       gapTitle:"⚠️ SPIRAL GAP ANALYSIS:",
       recTitle:"💡 RECOMMENDATION:",
-      stageMeaning:{beige:"Survival",purple:"Traditional/Family",red:"Inequality/Rebellion",blue:"Order/Discipline",orange:"Achievement/Middle Class",green:"Empathy/Mutual Aid",yellow:"Flexible/Adaptive",turquoise:"Holistic/Global"}
+      stageMeaning:{beige:"Survival",purple:"Traditional/Family",red:"Inequality/Rebellion",blue:"Order/Discipline",orange:"Achievement/Middle Class",green:"Empathy/Mutual Aid",yellow:"Flexible/Adaptive",turquoise:"Holistic/Global"},
+      mismatchScoreLabel:"Mismatch score:", mismatchRiskLabel:"Risk level:", mismatchDriverLabel:"Primary driver:",
+      riskLevels:{low:"low",medium:"medium",high:"high"},
+      driverLabels:{redPressure:"Red pressure",empathyGap:"Empathy gap",stageMismatch:"Structural stage gap",welfareScorePenalty:"Low welfare score",esgClaimMismatch:"ESG claim mismatch"}
     }
   };
 

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -160,7 +160,9 @@
     const esgInput = $('esgText') ? $('esgText').value : '';
     const mismatch = window.calculateMismatch({ score: sc, spiral }, esgInput);
     $('mismatchVal').textContent = mismatch.mismatchScore.toFixed(2);
-    $('mismatchText').textContent = mismatch.mismatchDescription[window.i18n.lang] || mismatch.mismatchDescription.en;
+    $('mismatchRiskLevel').textContent = window.i18n.tr[window.i18n.lang].riskLevels[mismatch.riskLevel] || mismatch.riskLevel;
+    $('mismatchDriver').textContent = window.i18n.tr[window.i18n.lang].driverLabels[mismatch.primaryDriver] || mismatch.primaryDriver;
+    $('mismatchText').textContent = mismatch.explanationText[window.i18n.lang] || mismatch.explanationText.en;
     const gap=d.pg/Math.max(d.ig,0.1);
     const wb=$('warnBox'),wt=$('warnText');
     if(gap>5&&d.cc>40){wb.style.background='#fef2f2';wb.style.color='var(--d)';wt.textContent=window.i18n.lang==='ru'?`Прибыль банка растёт в ${Math.round(gap)} раз быстрее доходов населения. Высокая доля потребительских кредитов (${d.cc}%) указывает на кредитование бедности, а не развития.`:`Bank profit grows ${Math.round(gap)}x faster than population income. High share of consumption loans (${d.cc}%) indicates lending to poverty, not development.`;}


### PR DESCRIPTION
### Motivation
- Make mismatch results understandable for non-technical users by deriving human-friendly explanations from existing metrics (`mismatchScore`, `esgConfidence`, and spiral stage mapping). 
- Surface a simple risk label and a primary driver so analysts and citizens can quickly grasp why a mismatch was flagged.

### Description
- Added an interpretation layer in `src/js/core/mismatch.js` that infers `riskLevel` (`low`/`medium`/`high`), determines a `primaryDriver` by comparing the weighted components (red pressure, empathy gap, structural stage mismatch, welfare-score penalty, ESG-claim mismatch), and builds `explanationText` in EN/RU without changing existing scoring math or removing debug logging. 
- Integrated the new outputs into the UI: `src/js/ui.js` now displays the `riskLevel`, `primaryDriver`, and `explanationText` alongside the existing mismatch score. 
- Added localized labels and mapping entries (EN/RU) in `src/js/i18n.js` and updated `index.html` markup to show `Mismatch score`, `Risk level`, and `Primary driver`. 
- Preserved all original scoring calculations and debug output; no conversion to ES modules was performed.

### Testing
- Ran static syntax checks: `node --check src/js/core/mismatch.js`, `node --check src/js/ui.js`, and `node --check src/js/i18n.js`, all of which passed. 
- Verified that the UI code references new i18n keys and DOM nodes (no automated UI tests were added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1cd91e5b08324ab910db9f72fd609)