### PR TITLE
Expose ESG and driver confidence with uncertainty indicators in mismatch UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,11 @@
     .stage-grid-detail{display:grid;grid-template-columns:repeat(8,1fr);gap:4px;text-align:center;font-size:.75rem;margin:8px 0}
     .stage-cell{padding:6px;background:#fff;border-radius:4px;font-weight:600}
     .dominant-text{margin-top:8px;font-weight:600;font-size:.9rem}
+    .confidence-row{display:grid;grid-template-columns:110px 1fr 42px;align-items:center;gap:8px}
+    .confidence-label{font-size:.78rem;color:var(--tm)}
+    .confidence-track{height:8px;background:var(--b);border-radius:999px;overflow:hidden}
+    .confidence-fill{height:100%;width:0%;background:var(--w);transition:width .35s ease, background .35s ease}
+    .confidence-val{font-size:.78rem;font-weight:600;color:var(--tm);text-align:right}
     @media(max-width:600px){
       body{padding:8px}header{padding:12px 14px;margin-bottom:12px}.logo{font-size:1rem}.logo-i{width:32px;height:32px;font-size:.85rem}.lang-b{padding:6px 12px;font-size:.85rem}.input-s{padding:14px;margin-bottom:12px;border-radius:10px}.input-h{flex-direction:column;align-items:flex-start;gap:8px;margin-bottom:14px}.sec-t{font-size:1.05rem;width:100%}.btn-p{width:100%;text-align:center;padding:13px 20px;font-size:1rem}.ex{padding:10px;margin-bottom:14px;border-radius:8px}.ex-label{width:100%;margin-bottom:6px;font-size:.8rem}.ex-b{flex:1;min-width:0;text-align:center;padding:8px 10px;font-size:.8rem}.form-g{grid-template-columns:1fr;gap:12px}.form-r{grid-template-columns:1fr;gap:10px}.form-gr input{padding:10px 12px;font-size:1rem}.res-t{font-size:1.05rem;margin-bottom:12px}.grid{grid-template-columns:1fr;gap:12px}.card{padding:14px;border-radius:10px}.card-t{font-size:1rem;margin-bottom:12px}.metric{flex-direction:column;align-items:flex-start;gap:4px;padding:8px 0}.metric-v{justify-content:flex-start;width:100%}.score-v{font-size:2.2rem}.score-l{font-size:.85rem}.chart-c{height:220px}.spiral-chart-container{height:320px}.stage-grid{grid-template-columns:1fr}.prob-i{padding:8px 0}.prob-i div:last-child{font-size:.85rem}.quest-i{font-size:.85rem;padding:8px 0}footer{padding:16px;font-size:.8rem}.stage-grid-detail{grid-template-columns:repeat(4,1fr)}
     }
@@ -178,7 +183,19 @@
           <div><strong id="mismatchScoreLabel">Mismatch score:</strong> <span id="mismatchVal">0.00</span></div>
           <div style="margin-top:4px;"><strong id="mismatchRiskLabel">Risk level:</strong> <span id="mismatchRiskLevel">-</span></div>
           <div style="margin-top:4px;"><strong id="mismatchDriverLabel">Primary driver:</strong> <span id="mismatchDriver">-</span></div>
-          <div id="mismatchText" style="margin-top:6px;font-size:.85rem;color:var(--tm)"></div>
+          <div style="margin-top:8px;display:grid;gap:6px;">
+            <div class="confidence-row">
+              <span class="confidence-label"><span id="esgConfidenceLabel">ESG confidence</span></span>
+              <div class="confidence-track"><div id="esgConfidenceBar" class="confidence-fill"></div></div>
+              <span id="esgConfidenceVal" class="confidence-val">0%</span>
+            </div>
+            <div class="confidence-row">
+              <span class="confidence-label"><span id="driverConfidenceLabel">Driver confidence</span></span>
+              <div class="confidence-track"><div id="driverConfidenceBar" class="confidence-fill"></div></div>
+              <span id="driverConfidenceVal" class="confidence-val">0%</span>
+            </div>
+          </div>
+          <div id="mismatchText" style="margin-top:8px;font-size:.85rem;color:var(--tm)"></div>
         </div>
       </div>
 

--- a/src/js/core/mismatch.js
+++ b/src/js/core/mismatch.js
@@ -171,7 +171,7 @@
       };
     }
 
-    function buildExplanationText(primaryDriver) {
+    function buildExplanationText(primaryDriver, driverConfidence) {
       const confidencePct = Math.round((esgSignal.confidence || 0) * 100);
       const labels = {
         redPressure: {
@@ -196,6 +196,13 @@
         }
       };
 
+      const uncertaintyBand = (esgSignal.confidence + driverConfidence) / 2;
+      const uncertaintyText = uncertaintyBand >= 0.75
+        ? { en: 'Uncertainty: low.', ru: 'Неопределенность: низкая.' }
+        : uncertaintyBand >= 0.45
+          ? { en: 'Uncertainty: medium.', ru: 'Неопределенность: средняя.' }
+          : { en: 'Uncertainty: high.', ru: 'Неопределенность: высокая.' };
+
       const riskText = severity === 'high'
         ? { en: 'High risk of extractive mismatch.', ru: 'Высокий риск экстрактивного несоответствия.' }
         : severity === 'medium'
@@ -203,15 +210,15 @@
           : { en: 'Low mismatch risk under current inputs.', ru: 'Низкий риск несоответствия при текущих данных.' };
 
       return {
-        en: `${riskText.en} Main reason: ${labels[primaryDriver].en} Mismatch score ${mismatchScore.toFixed(2)}. ESG confidence ${confidencePct}%. Dominant stages: bank ${bankDominant}, population ${popDominant}.`,
-        ru: `${riskText.ru} Главная причина: ${labels[primaryDriver].ru} Индекс несоответствия ${mismatchScore.toFixed(2)}. Уверенность ESG ${confidencePct}%. Доминирующие стадии: банк ${bankDominant}, население ${popDominant}.`
+        en: `${riskText.en} ${uncertaintyText.en} Main reason: ${labels[primaryDriver].en} Mismatch score ${mismatchScore.toFixed(2)}. ESG confidence ${confidencePct}%. Driver confidence ${Math.round(driverConfidence * 100)}%. Dominant stages: bank ${bankDominant}, population ${popDominant}.`,
+        ru: `${riskText.ru} ${uncertaintyText.ru} Главная причина: ${labels[primaryDriver].ru} Индекс несоответствия ${mismatchScore.toFixed(2)}. Уверенность ESG ${confidencePct}%. Уверенность драйвера ${Math.round(driverConfidence * 100)}%. Доминирующие стадии: банк ${bankDominant}, население ${popDominant}.`
       };
     }
 
     const driverInference = inferPrimaryDriver();
     const primaryDriver = driverInference.driver;
     const driverConfidence = driverInference.driverConfidence;
-    const explanationText = buildExplanationText(primaryDriver);
+    const explanationText = buildExplanationText(primaryDriver, driverConfidence);
 
     const mismatchDescription = {
       en: `Mismatch is ${severity}: bank dominant stage is ${bankDominant} (${bank[bankDominant] || 0}%) while population is ${popDominant} (${population[popDominant] || 0}%). Red pressure gap: ${Math.round(redGap)}pp, empathy gap: ${Math.round(greenGap)}pp.${esgSignal.hasInput ? ` ESG mapping confidence: ${Math.round((esgSignal.confidence || 0) * 100)}%.` : ''}${esgSignal.hasInput ? (esgSignal.claimsHighEsg ? ` ESG value stages detected: ${esgSignal.detectedStages.join(', ') || 'none'}. Expected behavior: ${esgSignal.primaryStage ? ((esgSignal.stageExpectations[esgSignal.primaryStage] || {}).en || 'not defined') : 'not defined'}` : ' ESG text provided but no strong sustainability claim detected.') : ''}`,

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -34,7 +34,7 @@
       gapTitle:"⚠️ АНАЛИЗ СПИРАЛЬНОГО РАЗРЫВА:",
       recTitle:"💡 РЕКОМЕНДАЦИЯ:",
       stageMeaning:{beige:"Выживание",purple:"Традиции/Семья",red:"Неравенство/Бунт",blue:"Порядок/Дисциплина",orange:"Достижение/Средний класс",green:"Эмпатия/Взаимопомощь",yellow:"Гибкость/Адаптация",turquoise:"Холизм/Глобальность"},
-      mismatchScoreLabel:"Mismatch индекс:", mismatchRiskLabel:"Уровень риска:", mismatchDriverLabel:"Главный драйвер:",
+      mismatchScoreLabel:"Mismatch индекс:", mismatchRiskLabel:"Уровень риска:", mismatchDriverLabel:"Главный драйвер:", esgConfidenceLabel:"Уверенность ESG:", driverConfidenceLabel:"Уверенность драйвера:",
       riskLevels:{low:"низкий",medium:"средний",high:"высокий"},
       driverLabels:{redPressure:"Давление Red",empathyGap:"Разрыв эмпатии",stageMismatch:"Структурный разрыв стадий",welfareScorePenalty:"Слабый welfare score",esgClaimMismatch:"Разрыв ESG-заявлений"}
     },
@@ -72,7 +72,7 @@
       gapTitle:"⚠️ SPIRAL GAP ANALYSIS:",
       recTitle:"💡 RECOMMENDATION:",
       stageMeaning:{beige:"Survival",purple:"Traditional/Family",red:"Inequality/Rebellion",blue:"Order/Discipline",orange:"Achievement/Middle Class",green:"Empathy/Mutual Aid",yellow:"Flexible/Adaptive",turquoise:"Holistic/Global"},
-      mismatchScoreLabel:"Mismatch score:", mismatchRiskLabel:"Risk level:", mismatchDriverLabel:"Primary driver:",
+      mismatchScoreLabel:"Mismatch score:", mismatchRiskLabel:"Risk level:", mismatchDriverLabel:"Primary driver:", esgConfidenceLabel:"ESG confidence:", driverConfidenceLabel:"Driver confidence:",
       riskLevels:{low:"low",medium:"medium",high:"high"},
       driverLabels:{redPressure:"Red pressure",empathyGap:"Empathy gap",stageMismatch:"Structural stage gap",welfareScorePenalty:"Low welfare score",esgClaimMismatch:"ESG claim mismatch"}
     }

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -162,6 +162,24 @@
     $('mismatchVal').textContent = mismatch.mismatchScore.toFixed(2);
     $('mismatchRiskLevel').textContent = window.i18n.tr[window.i18n.lang].riskLevels[mismatch.riskLevel] || mismatch.riskLevel;
     $('mismatchDriver').textContent = window.i18n.tr[window.i18n.lang].driverLabels[mismatch.primaryDriver] || mismatch.primaryDriver;
+
+    const esgConfidence = Math.max(0, Math.min(1, mismatch.esgConfidence || 0));
+    const driverConfidence = Math.max(0, Math.min(1, mismatch.driverConfidence || 0));
+    const esgPct = Math.round(esgConfidence * 100);
+    const driverPct = Math.round(driverConfidence * 100);
+
+    $('esgConfidenceVal').textContent = `${esgPct}%`;
+    $('driverConfidenceVal').textContent = `${driverPct}%`;
+
+    const esgBar = $('esgConfidenceBar');
+    const driverBar = $('driverConfidenceBar');
+    esgBar.style.width = `${esgPct}%`;
+    driverBar.style.width = `${driverPct}%`;
+
+    const pickColor = pct => pct >= 75 ? 'var(--s)' : pct >= 45 ? 'var(--w)' : 'var(--d)';
+    esgBar.style.background = pickColor(esgPct);
+    driverBar.style.background = pickColor(driverPct);
+
     $('mismatchText').textContent = mismatch.explanationText[window.i18n.lang] || mismatch.explanationText.en;
     const gap=d.pg/Math.max(d.ig,0.1);
     const wb=$('warnBox'),wt=$('warnText');


### PR DESCRIPTION
### Motivation
- Make uncertainty explicit to improve user trust by surfacing model confidence for ESG mapping and driver inference and by showing a simple uncertainty cue in the explanation text.
- Keep the UI minimal and non-intrusive while avoiding any changes to the existing scoring math or project architecture.

### Description
- Added compact confidence rows (bars + percentage) to the mismatch panel in `index.html` with minimal CSS for a lightweight visual indicator (`esgConfidenceBar`, `driverConfidenceBar`).
- Extended `src/js/core/mismatch.js` to return `driverConfidence`, accept it into `buildExplanationText`, and include an `uncertainty` band (low/medium/high) derived from the ESG and driver confidences in the human-readable explanation text.
- Updated `src/js/ui.js` to read `mismatch.esgConfidence` and `mismatch.driverConfidence`, render percentage readouts and fill the bars, and color-code bars with simple thresholds (green/amber/red) without changing scoring logic.
- Added i18n labels for the new UI strings in `src/js/i18n.js` so the confidence rows remain localized.

### Testing
- Ran syntax checks `node --check src/js/core/mismatch.js` and `node --check src/js/ui.js` and `node --check src/js/i18n.js`, all of which completed without errors.
- Confirmed the application scripts load and the new UI elements are updated by the existing `refresh`/`doAnalyze` flow during manual runs (no scoring formula or algorithmic outputs were changed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d0ff365c83248313c0a26dd23276)