### PR TITLE
Add deterministic predictive consequences to mismatch explanation

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,6 +196,14 @@
             </div>
           </div>
           <div id="mismatchText" style="margin-top:8px;font-size:.85rem;color:var(--tm)"></div>
+          <div style="margin-top:8px;font-size:.85rem;color:var(--tm)">
+            <strong id="shortTermLabel">Short-term consequence:</strong>
+            <div id="mismatchShortTerm" style="margin-top:4px;"></div>
+          </div>
+          <div style="margin-top:8px;font-size:.85rem;color:var(--tm)">
+            <strong id="longTermLabel">Long-term consequence:</strong>
+            <div id="mismatchLongTerm" style="margin-top:4px;"></div>
+          </div>
         </div>
       </div>
 

--- a/src/js/core/mismatch.js
+++ b/src/js/core/mismatch.js
@@ -215,10 +215,87 @@
       };
     }
 
+    function buildPredictiveImpact(primaryDriver) {
+      const stageGap = (bank[bankDominant] || 0) - (population[popDominant] || 0);
+      const tensionLevel = mismatchScore >= 0.67 ? 'high' : mismatchScore >= 0.34 ? 'medium' : 'low';
+      const stageContext = {
+        en: `Bank dominant stage ${bankDominant} (${bank[bankDominant] || 0}%) vs population ${popDominant} (${population[popDominant] || 0}%), gap ${Math.round(stageGap)}pp.`,
+        ru: `Доминирующая стадия банка ${bankDominant} (${bank[bankDominant] || 0}%) против населения ${popDominant} (${population[popDominant] || 0}%), разрыв ${Math.round(stageGap)} п.п.`
+      };
+      const driverImpact = {
+        redPressure: {
+          shortTerm: {
+            en: 'Higher repayment pressure and faster debt rollover among vulnerable households.',
+            ru: 'Рост давления на погашение и ускорение перекредитования у уязвимых домохозяйств.'
+          },
+          longTerm: {
+            en: 'Rising social resentment and weakening trust in formal finance channels.',
+            ru: 'Рост социального раздражения и снижение доверия к формальным финансовым каналам.'
+          }
+        },
+        empathyGap: {
+          shortTerm: {
+            en: 'More reliance on informal mutual aid to cover loan servicing shocks.',
+            ru: 'Усиление опоры на неформальную взаимопомощь для покрытия кредитных шоков.'
+          },
+          longTerm: {
+            en: 'Exclusion of fragile borrowers from healthy credit cycles and slower mobility.',
+            ru: 'Исключение хрупких заемщиков из здоровых кредитных циклов и замедление мобильности.'
+          }
+        },
+        stageMismatch: {
+          shortTerm: {
+            en: 'Policy communication friction: bank products fit bank culture better than social needs.',
+            ru: 'Трение в коммуникации: продукты банка лучше соответствуют культуре банка, чем нуждам общества.'
+          },
+          longTerm: {
+            en: 'Persistent institutional mismatch can lock the system into low-welfare credit patterns.',
+            ru: 'Устойчивое институциональное несоответствие закрепляет низко-благосостоянные кредитные паттерны.'
+          }
+        },
+        welfareScorePenalty: {
+          shortTerm: {
+            en: 'Current welfare baseline limits immediate inclusive impact of new lending.',
+            ru: 'Текущая база благосостояния ограничивает немедленный инклюзивный эффект нового кредитования.'
+          },
+          longTerm: {
+            en: 'Without welfare recovery, credit expansion risks amplifying inequality over time.',
+            ru: 'Без восстановления благосостояния расширение кредитования со временем усиливает неравенство.'
+          }
+        },
+        esgClaimMismatch: {
+          shortTerm: {
+            en: 'Credibility gap between ESG messaging and borrower experience may widen quickly.',
+            ru: 'Разрыв доверия между ESG-риторикой и опытом заемщиков может быстро расшириться.'
+          },
+          longTerm: {
+            en: 'Sustained claim-behavior inconsistency may erode brand legitimacy and reform capacity.',
+            ru: 'Длительное расхождение заявлений и поведения подрывает легитимность бренда и способность к реформам.'
+          }
+        }
+      };
+
+      const selected = driverImpact[primaryDriver] || driverImpact.stageMismatch;
+      const riskPrefix = tensionLevel === 'high'
+        ? { en: 'Near-term risk is elevated.', ru: 'Краткосрочный риск повышен.' }
+        : tensionLevel === 'medium'
+          ? { en: 'Near-term risk is manageable but active.', ru: 'Краткосрочный риск управляемый, но активный.' }
+          : { en: 'Near-term risk is limited under current inputs.', ru: 'Краткосрочный риск ограничен при текущих данных.' };
+
+      return {
+        shortTerm: {
+          en: `${riskPrefix.en} ${selected.shortTerm.en} ${stageContext.en}`,
+          ru: `${riskPrefix.ru} ${selected.shortTerm.ru} ${stageContext.ru}`
+        },
+        longTerm: selected.longTerm
+      };
+    }
+
     const driverInference = inferPrimaryDriver();
     const primaryDriver = driverInference.driver;
     const driverConfidence = driverInference.driverConfidence;
     const explanationText = buildExplanationText(primaryDriver, driverConfidence);
+    const predictiveImpact = buildPredictiveImpact(primaryDriver);
 
     const mismatchDescription = {
       en: `Mismatch is ${severity}: bank dominant stage is ${bankDominant} (${bank[bankDominant] || 0}%) while population is ${popDominant} (${population[popDominant] || 0}%). Red pressure gap: ${Math.round(redGap)}pp, empathy gap: ${Math.round(greenGap)}pp.${esgSignal.hasInput ? ` ESG mapping confidence: ${Math.round((esgSignal.confidence || 0) * 100)}%.` : ''}${esgSignal.hasInput ? (esgSignal.claimsHighEsg ? ` ESG value stages detected: ${esgSignal.detectedStages.join(', ') || 'none'}. Expected behavior: ${esgSignal.primaryStage ? ((esgSignal.stageExpectations[esgSignal.primaryStage] || {}).en || 'not defined') : 'not defined'}` : ' ESG text provided but no strong sustainability claim detected.') : ''}`,
@@ -233,6 +310,7 @@
       primaryDriver,
       driverConfidence,
       explanationText,
+      predictiveImpact,
       mismatchDescription
     };
   }

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -34,7 +34,7 @@
       gapTitle:"⚠️ АНАЛИЗ СПИРАЛЬНОГО РАЗРЫВА:",
       recTitle:"💡 РЕКОМЕНДАЦИЯ:",
       stageMeaning:{beige:"Выживание",purple:"Традиции/Семья",red:"Неравенство/Бунт",blue:"Порядок/Дисциплина",orange:"Достижение/Средний класс",green:"Эмпатия/Взаимопомощь",yellow:"Гибкость/Адаптация",turquoise:"Холизм/Глобальность"},
-      mismatchScoreLabel:"Mismatch индекс:", mismatchRiskLabel:"Уровень риска:", mismatchDriverLabel:"Главный драйвер:", esgConfidenceLabel:"Уверенность ESG:", driverConfidenceLabel:"Уверенность драйвера:",
+      mismatchScoreLabel:"Mismatch индекс:", mismatchRiskLabel:"Уровень риска:", mismatchDriverLabel:"Главный драйвер:", esgConfidenceLabel:"Уверенность ESG:", driverConfidenceLabel:"Уверенность драйвера:", shortTermLabel:"Краткосрочное последствие:", longTermLabel:"Долгосрочное последствие:",
       riskLevels:{low:"низкий",medium:"средний",high:"высокий"},
       driverLabels:{redPressure:"Давление Red",empathyGap:"Разрыв эмпатии",stageMismatch:"Структурный разрыв стадий",welfareScorePenalty:"Слабый welfare score",esgClaimMismatch:"Разрыв ESG-заявлений"}
     },
@@ -72,7 +72,7 @@
       gapTitle:"⚠️ SPIRAL GAP ANALYSIS:",
       recTitle:"💡 RECOMMENDATION:",
       stageMeaning:{beige:"Survival",purple:"Traditional/Family",red:"Inequality/Rebellion",blue:"Order/Discipline",orange:"Achievement/Middle Class",green:"Empathy/Mutual Aid",yellow:"Flexible/Adaptive",turquoise:"Holistic/Global"},
-      mismatchScoreLabel:"Mismatch score:", mismatchRiskLabel:"Risk level:", mismatchDriverLabel:"Primary driver:", esgConfidenceLabel:"ESG confidence:", driverConfidenceLabel:"Driver confidence:",
+      mismatchScoreLabel:"Mismatch score:", mismatchRiskLabel:"Risk level:", mismatchDriverLabel:"Primary driver:", esgConfidenceLabel:"ESG confidence:", driverConfidenceLabel:"Driver confidence:", shortTermLabel:"Short-term consequence:", longTermLabel:"Long-term consequence:",
       riskLevels:{low:"low",medium:"medium",high:"high"},
       driverLabels:{redPressure:"Red pressure",empathyGap:"Empathy gap",stageMismatch:"Structural stage gap",welfareScorePenalty:"Low welfare score",esgClaimMismatch:"ESG claim mismatch"}
     }

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -181,6 +181,11 @@
     driverBar.style.background = pickColor(driverPct);
 
     $('mismatchText').textContent = mismatch.explanationText[window.i18n.lang] || mismatch.explanationText.en;
+    const predictive = mismatch.predictiveImpact || {};
+    const shortTerm = predictive.shortTerm ? (predictive.shortTerm[window.i18n.lang] || predictive.shortTerm.en) : '-';
+    const longTerm = predictive.longTerm ? (predictive.longTerm[window.i18n.lang] || predictive.longTerm.en) : '-';
+    $('mismatchShortTerm').textContent = shortTerm;
+    $('mismatchLongTerm').textContent = longTerm;
     const gap=d.pg/Math.max(d.ig,0.1);
     const wb=$('warnBox'),wt=$('warnText');
     if(gap>5&&d.cc>40){wb.style.background='#fef2f2';wb.style.color='var(--d)';wt.textContent=window.i18n.lang==='ru'?`Прибыль банка растёт в ${Math.round(gap)} раз быстрее доходов населения. Высокая доля потребительских кредитов (${d.cc}%) указывает на кредитование бедности, а не развития.`:`Bank profit grows ${Math.round(gap)}x faster than population income. High share of consumption loans (${d.cc}%) indicates lending to poverty, not development.`;}


### PR DESCRIPTION
### Motivation
- Provide a predictive layer that explains likely short-term and long-term impacts of the current bank behavior using existing mismatch outputs to help stakeholders anticipate future welfare effects.
- Keep the change additive and non-invasive so existing scoring, driver inference and confidence outputs remain unchanged.

### Description
- Added `buildPredictiveImpact` inside `calculateMismatch` to deterministically derive `predictiveImpact.shortTerm` and `predictiveImpact.longTerm` from `mismatchScore`, `primaryDriver`, and dominant-stage (bank vs population) context. (modified: `src/js/core/mismatch.js`)
- Extended the mismatch return payload with `predictiveImpact` so callers can access the generated consequences. (modified: `src/js/core/mismatch.js`)
- Integrated the new fields into the existing explanation UI by adding UI blocks and rendering short-term and long-term consequence text. (modified: `index.html`, `src/js/ui.js`)
- Added RU/EN i18n labels for the new consequence sections to `src/js/i18n.js` and preserved existing logic and module structure (no ES module conversion). 

### Testing
- Ran repository inspections and diffs (`git status`, `git diff`, `nl`/`sed` file previews) to verify changes and confirm the new fields are wired into the UI, and these commands completed successfully. 
- Committed the changes (`git commit -m "Add deterministic predictive consequences to mismatch explanation"`) which succeeded. 
- No unit test suite was present or executed; the change is deterministic and purely local with no external API calls and did not alter existing scoring formulas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d2c5b7c08324b329e5c1a262a741)