### PR TITLE
Refine predictive messaging with uncertainty qualifiers and add scenario disclaimer

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,6 +204,7 @@
             <strong id="longTermLabel">Long-term consequence:</strong>
             <div id="mismatchLongTerm" style="margin-top:4px;"></div>
           </div>
+          <div id="predictiveDisclaimer" style="margin-top:10px;padding:8px;border-radius:6px;background:#fff7ed;border:1px solid #fed7aa;font-size:.8rem;color:#9a3412">⚠️ Scenario-based projection: indicative only, not a guaranteed outcome.</div>
         </div>
       </div>
 

--- a/src/js/core/mismatch.js
+++ b/src/js/core/mismatch.js
@@ -215,7 +215,27 @@
       };
     }
 
-    function buildPredictiveImpact(primaryDriver) {
+    function confidenceTone(driverConfidence) {
+      const combined = clamp01(((esgSignal.confidence || 0) + (driverConfidence || 0)) / 2);
+      if (combined >= 0.75) {
+        return {
+          qualifier: { en: 'is likely to', ru: 'с высокой вероятностью может' },
+          context: { en: 'Signal confidence is relatively high for this scenario.', ru: 'Уверенность сигнала относительно высокая для этого сценария.' }
+        };
+      }
+      if (combined >= 0.45) {
+        return {
+          qualifier: { en: 'may', ru: 'может' },
+          context: { en: 'Signal confidence is moderate, so outcomes are uncertain.', ru: 'Уверенность сигнала средняя, поэтому исходы неопределенны.' }
+        };
+      }
+      return {
+        qualifier: { en: 'could potentially', ru: 'потенциально может' },
+        context: { en: 'Signal confidence is limited, so treat this as an early warning.', ru: 'Уверенность сигнала ограниченная, воспринимайте это как ранний сигнал.' }
+      };
+    }
+
+    function buildPredictiveImpact(primaryDriver, driverConfidence) {
       const stageGap = (bank[bankDominant] || 0) - (population[popDominant] || 0);
       const tensionLevel = mismatchScore >= 0.67 ? 'high' : mismatchScore >= 0.34 ? 'medium' : 'low';
       const stageContext = {
@@ -225,38 +245,38 @@
       const driverImpact = {
         redPressure: {
           shortTerm: {
-            en: 'Higher repayment pressure and faster debt rollover among vulnerable households.',
-            ru: 'Рост давления на погашение и ускорение перекредитования у уязвимых домохозяйств.'
+            en: 'higher repayment pressure and faster debt rollover among vulnerable households',
+            ru: 'рост давления на погашение и ускорение перекредитования у уязвимых домохозяйств'
           },
           longTerm: {
-            en: 'Rising social resentment and weakening trust in formal finance channels.',
-            ru: 'Рост социального раздражения и снижение доверия к формальным финансовым каналам.'
+            en: 'rising social resentment and weaker trust in formal finance channels',
+            ru: 'рост социального раздражения и снижение доверия к формальным финансовым каналам'
           }
         },
         empathyGap: {
           shortTerm: {
-            en: 'More reliance on informal mutual aid to cover loan servicing shocks.',
-            ru: 'Усиление опоры на неформальную взаимопомощь для покрытия кредитных шоков.'
+            en: 'more reliance on informal mutual aid to cover loan-servicing shocks',
+            ru: 'усиление опоры на неформальную взаимопомощь для покрытия кредитных шоков'
           },
           longTerm: {
-            en: 'Exclusion of fragile borrowers from healthy credit cycles and slower mobility.',
-            ru: 'Исключение хрупких заемщиков из здоровых кредитных циклов и замедление мобильности.'
+            en: 'exclusion of fragile borrowers from healthy credit cycles and slower mobility',
+            ru: 'исключение хрупких заемщиков из здоровых кредитных циклов и замедление мобильности'
           }
         },
         stageMismatch: {
           shortTerm: {
-            en: 'Policy communication friction: bank products fit bank culture better than social needs.',
-            ru: 'Трение в коммуникации: продукты банка лучше соответствуют культуре банка, чем нуждам общества.'
+            en: 'policy communication friction: bank products fit bank culture better than social needs',
+            ru: 'трение в коммуникации: продукты банка лучше соответствуют культуре банка, чем нуждам общества'
           },
           longTerm: {
-            en: 'Persistent institutional mismatch can lock the system into low-welfare credit patterns.',
-            ru: 'Устойчивое институциональное несоответствие закрепляет низко-благосостоянные кредитные паттерны.'
+            en: 'persistent institutional mismatch that can lock the system into low-welfare credit patterns',
+            ru: 'устойчивое институциональное несоответствие, закрепляющее низко-благосостоянные кредитные паттерны'
           }
         },
         welfareScorePenalty: {
           shortTerm: {
-            en: 'Current welfare baseline limits immediate inclusive impact of new lending.',
-            ru: 'Текущая база благосостояния ограничивает немедленный инклюзивный эффект нового кредитования.'
+            en: 'current welfare baseline limiting immediate inclusive impact of new lending',
+            ru: 'текущая база благосостояния, ограничивающая немедленный инклюзивный эффект нового кредитования'
           },
           longTerm: {
             en: 'Without welfare recovery, credit expansion risks amplifying inequality over time.',
@@ -276,18 +296,22 @@
       };
 
       const selected = driverImpact[primaryDriver] || driverImpact.stageMismatch;
+      const tone = confidenceTone(driverConfidence);
       const riskPrefix = tensionLevel === 'high'
-        ? { en: 'Near-term risk is elevated.', ru: 'Краткосрочный риск повышен.' }
+        ? { en: 'Near-term risk is likely elevated.', ru: 'Краткосрочный риск, вероятно, повышен.' }
         : tensionLevel === 'medium'
-          ? { en: 'Near-term risk is manageable but active.', ru: 'Краткосрочный риск управляемый, но активный.' }
-          : { en: 'Near-term risk is limited under current inputs.', ru: 'Краткосрочный риск ограничен при текущих данных.' };
+          ? { en: 'Near-term risk may be manageable but active.', ru: 'Краткосрочный риск может быть управляемым, но активным.' }
+          : { en: 'Near-term risk could be limited under current inputs.', ru: 'Краткосрочный риск может быть ограничен при текущих данных.' };
 
       return {
         shortTerm: {
-          en: `${riskPrefix.en} ${selected.shortTerm.en} ${stageContext.en}`,
-          ru: `${riskPrefix.ru} ${selected.shortTerm.ru} ${stageContext.ru}`
+          en: `${riskPrefix.en} This scenario ${tone.qualifier.en} lead to ${selected.shortTerm.en}. ${tone.context.en} ${stageContext.en}`,
+          ru: `${riskPrefix.ru} Этот сценарий ${tone.qualifier.ru} привести к следующему: ${selected.shortTerm.ru}. ${tone.context.ru} ${stageContext.ru}`
         },
-        longTerm: selected.longTerm
+        longTerm: {
+          en: `Over time, this scenario ${tone.qualifier.en} contribute to ${selected.longTerm.en} ${tone.context.en} ${stageContext.en}`,
+          ru: `Со временем этот сценарий ${tone.qualifier.ru} привести к следующему: ${selected.longTerm.ru} ${tone.context.ru} ${stageContext.ru}`
+        }
       };
     }
 
@@ -295,7 +319,7 @@
     const primaryDriver = driverInference.driver;
     const driverConfidence = driverInference.driverConfidence;
     const explanationText = buildExplanationText(primaryDriver, driverConfidence);
-    const predictiveImpact = buildPredictiveImpact(primaryDriver);
+    const predictiveImpact = buildPredictiveImpact(primaryDriver, driverConfidence);
 
     const mismatchDescription = {
       en: `Mismatch is ${severity}: bank dominant stage is ${bankDominant} (${bank[bankDominant] || 0}%) while population is ${popDominant} (${population[popDominant] || 0}%). Red pressure gap: ${Math.round(redGap)}pp, empathy gap: ${Math.round(greenGap)}pp.${esgSignal.hasInput ? ` ESG mapping confidence: ${Math.round((esgSignal.confidence || 0) * 100)}%.` : ''}${esgSignal.hasInput ? (esgSignal.claimsHighEsg ? ` ESG value stages detected: ${esgSignal.detectedStages.join(', ') || 'none'}. Expected behavior: ${esgSignal.primaryStage ? ((esgSignal.stageExpectations[esgSignal.primaryStage] || {}).en || 'not defined') : 'not defined'}` : ' ESG text provided but no strong sustainability claim detected.') : ''}`,

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -34,7 +34,7 @@
       gapTitle:"⚠️ АНАЛИЗ СПИРАЛЬНОГО РАЗРЫВА:",
       recTitle:"💡 РЕКОМЕНДАЦИЯ:",
       stageMeaning:{beige:"Выживание",purple:"Традиции/Семья",red:"Неравенство/Бунт",blue:"Порядок/Дисциплина",orange:"Достижение/Средний класс",green:"Эмпатия/Взаимопомощь",yellow:"Гибкость/Адаптация",turquoise:"Холизм/Глобальность"},
-      mismatchScoreLabel:"Mismatch индекс:", mismatchRiskLabel:"Уровень риска:", mismatchDriverLabel:"Главный драйвер:", esgConfidenceLabel:"Уверенность ESG:", driverConfidenceLabel:"Уверенность драйвера:", shortTermLabel:"Краткосрочное последствие:", longTermLabel:"Долгосрочное последствие:",
+      mismatchScoreLabel:"Mismatch индекс:", mismatchRiskLabel:"Уровень риска:", mismatchDriverLabel:"Главный драйвер:", esgConfidenceLabel:"Уверенность ESG:", driverConfidenceLabel:"Уверенность драйвера:", shortTermLabel:"Краткосрочное последствие:", longTermLabel:"Долгосрочное последствие:", predictiveDisclaimer:"⚠️ Сценарный прогноз: это ориентировочная оценка, а не гарантированный результат.",
       riskLevels:{low:"низкий",medium:"средний",high:"высокий"},
       driverLabels:{redPressure:"Давление Red",empathyGap:"Разрыв эмпатии",stageMismatch:"Структурный разрыв стадий",welfareScorePenalty:"Слабый welfare score",esgClaimMismatch:"Разрыв ESG-заявлений"}
     },
@@ -72,7 +72,7 @@
       gapTitle:"⚠️ SPIRAL GAP ANALYSIS:",
       recTitle:"💡 RECOMMENDATION:",
       stageMeaning:{beige:"Survival",purple:"Traditional/Family",red:"Inequality/Rebellion",blue:"Order/Discipline",orange:"Achievement/Middle Class",green:"Empathy/Mutual Aid",yellow:"Flexible/Adaptive",turquoise:"Holistic/Global"},
-      mismatchScoreLabel:"Mismatch score:", mismatchRiskLabel:"Risk level:", mismatchDriverLabel:"Primary driver:", esgConfidenceLabel:"ESG confidence:", driverConfidenceLabel:"Driver confidence:", shortTermLabel:"Short-term consequence:", longTermLabel:"Long-term consequence:",
+      mismatchScoreLabel:"Mismatch score:", mismatchRiskLabel:"Risk level:", mismatchDriverLabel:"Primary driver:", esgConfidenceLabel:"ESG confidence:", driverConfidenceLabel:"Driver confidence:", shortTermLabel:"Short-term consequence:", longTermLabel:"Long-term consequence:", predictiveDisclaimer:"⚠️ Scenario-based projection: indicative only, not a guaranteed outcome.",
       riskLevels:{low:"low",medium:"medium",high:"high"},
       driverLabels:{redPressure:"Red pressure",empathyGap:"Empathy gap",stageMismatch:"Structural stage gap",welfareScorePenalty:"Low welfare score",esgClaimMismatch:"ESG claim mismatch"}
     }


### PR DESCRIPTION
### Motivation
- Reduce overconfident predictive language by surfacing uncertainty and making outputs scenario-based rather than definitive.
- Adjust tone of predictive consequences according to combined ESG + driver confidence so users get clearer signals about reliability.
- Provide an explicit UI disclaimer clarifying that predictive outputs are indicative scenarios and not guaranteed outcomes.

### Description
- Added a `confidenceTone` helper and updated `buildPredictiveImpact` in `src/js/core/mismatch.js` to accept `driverConfidence` and emit uncertainty qualifiers (`is likely to`, `may`, `could potentially`) based on combined confidence bands. 
- Reframed short- and long-term predictive text to present outcomes as scenario-driven possibilities and appended confidence context to the messages without changing scoring math.
- Inserted a scenario disclaimer into the existing mismatch panel in `index.html` so the UI layout and structure remain unchanged.
- Added RU/EN i18n keys for the new disclaimer in `src/js/i18n.js` so language switching continues to work.

### Testing
- Performed static syntax checks: `node --check src/js/core/mismatch.js` — succeeded.
- Performed static syntax checks: `node --check src/js/i18n.js` — succeeded.
- Performed static syntax checks: `node --check src/js/ui.js` — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21aea582c8324822b5603145ca476)