### PR TITLE
Add analyzeBank engine and route UI through it

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,6 +242,7 @@
     <script src="src/js/core/scoring.js"></script>
     <script src="src/js/core/valueMapping.js"></script>
     <script src="src/js/core/mismatch.js"></script>
+    <script src="src/js/core/engine.js"></script>
     <script src="src/js/ui.js"></script>
 
 </body>

--- a/src/js/core/engine.js
+++ b/src/js/core/engine.js
@@ -1,0 +1,19 @@
+(function () {
+  function analyzeBank(data) {
+    const esgInput = data && typeof data.esgText === 'string' ? data.esgText : '';
+    const score = window.calcScore(data);
+    const spiral = window.calculateSpiralStages(data);
+    const behavior = window.mapValuesToBehavior(esgInput);
+    const mismatch = window.calculateMismatch({ score, spiral }, esgInput);
+
+    return {
+      data,
+      score,
+      spiral,
+      behavior,
+      mismatch
+    };
+  }
+
+  window.analyzeBank = analyzeBank;
+})();

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -148,17 +148,18 @@
       window.chart=new Chart(ctx,{type:'doughnut',data:{labels:[window.i18n.tr[window.i18n.lang].cons,window.i18n.tr[window.i18n.lang].bus,window.i18n.tr[window.i18n.lang].other],datasets:[{data:[d.cc,d.cb,d.co2],backgroundColor:['#dc2626','#16a34a','#64748b'],borderWidth:0,spacing:2}]},options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{position:'bottom',labels:{usePointStyle:true,padding:20,font:{size:11}}},tooltip:{callbacks:{label:c=>c.label+': '+c.parsed+'%'}}},cutout:'65%'}});
     }else{window.chart.data.labels=[window.i18n.tr[window.i18n.lang].cons,window.i18n.tr[window.i18n.lang].bus,window.i18n.tr[window.i18n.lang].other];window.chart.data.datasets[0].data=[d.cc,d.cb,d.co2];window.chart.update();}
 
-    const spiral=window.calculateSpiralStages(d);
+    const esgInput = $('esgText') ? $('esgText').value : '';
+    const analysis = window.analyzeBank({ ...d, esgText: esgInput });
+    const spiral=analysis.spiral;
     initSpiralChart(spiral.population,spiral.bank);
     renderDetailedAnalysis(d,spiral.population,spiral.bank);
 
-    const sc=window.calcScore(d);
+    const sc=analysis.score;
     $('scoreVal').textContent=sc+'/100';
     const sf=$('scoreFill');sf.style.width=sc+'%';
     sf.style.background=sc<40?'var(--d)':sc<70?'var(--w)':'var(--s)';
 
-    const esgInput = $('esgText') ? $('esgText').value : '';
-    const mismatch = window.calculateMismatch({ score: sc, spiral }, esgInput);
+    const mismatch = analysis.mismatch;
     $('mismatchVal').textContent = mismatch.mismatchScore.toFixed(2);
     $('mismatchRiskLevel').textContent = window.i18n.tr[window.i18n.lang].riskLevels[mismatch.riskLevel] || mismatch.riskLevel;
     $('mismatchDriver').textContent = window.i18n.tr[window.i18n.lang].driverLabels[mismatch.primaryDriver] || mismatch.primaryDriver;


### PR DESCRIPTION
### Motivation
- Centralize the analysis pipeline so UI code no longer orchestrates business logic calls directly.
- Decouple UI from scoring/spiral/mismatch orchestration to make future changes easier while preserving behavior.
- Provide a single entrypoint that returns a full structured analysis object for reuse.

### Description
- Added new module `src/js/core/engine.js` that implements `analyzeBank(data)` and exposes it as `window.analyzeBank`.
- `analyzeBank` calls `calcScore`, `calculateSpiralStages`, `mapValuesToBehavior`, and `calculateMismatch`, and returns a structured object with `data`, `score`, `spiral`, `behavior`, and `mismatch`.
- Refactored `src/js/ui.js` to call `window.analyzeBank(...)` and consume `analysis.score` / `analysis.spiral` / `analysis.mismatch` instead of invoking scoring/spiral/mismatch functions directly, preserving existing UI rendering logic.
- Updated `index.html` to load `src/js/core/engine.js` before `src/js/ui.js`; no ES module conversion and no changes to scoring or mismatch formulas.

### Testing
- Ran `node --check src/js/core/engine.js` which succeeded.
- Ran `node --check src/js/ui.js` which succeeded.
- Verified script order in `index.html` and that `window.analyzeBank` is available; UI behavior unchanged during manual verification steps (no automated UI tests present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2633ab96c8324b63b643695240c9b)