### PR TITLE
Add multi-bank analysis and ranking capability

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,6 +243,7 @@
     <script src="src/js/core/valueMapping.js"></script>
     <script src="src/js/core/mismatch.js"></script>
     <script src="src/js/core/engine.js"></script>
+    <script src="src/js/core/ranking.js"></script>
     <script src="src/js/ui.js"></script>
 
 </body>

--- a/src/js/core/ranking.js
+++ b/src/js/core/ranking.js
@@ -1,0 +1,56 @@
+(function () {
+  const riskPriority = { low: 0, medium: 1, high: 2 };
+
+  function normalizeRiskLevel(level) {
+    const safeLevel = typeof level === 'string' ? level.toLowerCase() : '';
+    return Object.prototype.hasOwnProperty.call(riskPriority, safeLevel) ? safeLevel : 'high';
+  }
+
+  function toComparableResult(item) {
+    const source = item || {};
+    const mismatch = source.mismatch || {};
+    const mismatchScore = Number(mismatch.mismatchScore);
+    const riskLevel = normalizeRiskLevel(mismatch.riskLevel);
+
+    return {
+      ...source,
+      mismatch: {
+        ...mismatch,
+        mismatchScore: Number.isFinite(mismatchScore) ? mismatchScore : 1,
+        riskLevel
+      }
+    };
+  }
+
+  function rankBanks(resultsArray) {
+    const safeResults = Array.isArray(resultsArray) ? resultsArray : [];
+
+    return safeResults
+      .map((result, index) => ({
+        originalIndex: index,
+        analyzed: toComparableResult(result)
+      }))
+      .sort((a, b) => {
+        const riskDelta = riskPriority[a.analyzed.mismatch.riskLevel] - riskPriority[b.analyzed.mismatch.riskLevel];
+        if (riskDelta !== 0) return riskDelta;
+
+        const mismatchDelta = a.analyzed.mismatch.mismatchScore - b.analyzed.mismatch.mismatchScore;
+        if (mismatchDelta !== 0) return mismatchDelta;
+
+        return a.originalIndex - b.originalIndex;
+      })
+      .map((entry, rankIndex) => ({
+        rank: rankIndex + 1,
+        ...entry.analyzed
+      }));
+  }
+
+  function analyzeMultipleBanks(banksArray) {
+    const safeBanks = Array.isArray(banksArray) ? banksArray : [];
+    const analyzed = safeBanks.map((bank) => window.analyzeBank(bank));
+    return rankBanks(analyzed);
+  }
+
+  window.rankBanks = rankBanks;
+  window.analyzeMultipleBanks = analyzeMultipleBanks;
+})();


### PR DESCRIPTION
### Motivation
- Enable comparing and ranking multiple banks by reusing existing `analyzeBank` and producing a single ordered list for multi-bank workflows.
- Keep all existing scoring and analysis logic unchanged and expose a small, non-module browser API for UI or integrations.

### Description
- Add `src/js/core/ranking.js` which implements `analyzeMultipleBanks(banksArray)` and `rankBanks(resultsArray)` and exposes them as `window.analyzeMultipleBanks` and `window.rankBanks`.
- Ranking sorts first by `mismatch.riskLevel` (`low` -> `medium` -> `high`) and then by lower `mismatch.mismatchScore`, with a stable fallback to original order.
- Include defensive normalization of risk levels and mismatch scores so missing or malformed fields get sensible defaults.
- Wire the new script into `index.html` via a plain script tag without converting to modules or changing `analyzeBank` or scoring logic.

### Testing
- No automated tests were present in the repository, so no automated test suite was run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2673fad3c83248ba5ebb173b19f17)