### PR TITLE
Add multi-bank ranking leaderboard to UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,16 @@
     .confidence-track{height:8px;background:var(--b);border-radius:999px;overflow:hidden}
     .confidence-fill{height:100%;width:0%;background:var(--w);transition:width .35s ease, background .35s ease}
     .confidence-val{font-size:.78rem;font-weight:600;color:var(--tm);text-align:right}
+
+    .leaderboard-section{margin-top:16px}
+    .leaderboard-input{width:100%;min-height:120px;padding:11px 13px;border:1px solid var(--b);border-radius:8px;background:var(--ib);font-size:.9rem;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;resize:vertical}
+    .leaderboard-note{font-size:.82rem;color:var(--tm);margin-top:6px}
+    .leaderboard-list{display:grid;gap:10px;margin-top:12px}
+    .leaderboard-item{padding:12px;background:var(--ib);border-radius:8px;border:1px solid var(--b)}
+    .leaderboard-head{display:flex;justify-content:space-between;gap:10px;flex-wrap:wrap;font-size:.92rem}
+    .leaderboard-rank{font-weight:700;color:var(--p)}
+    .leaderboard-meta{display:flex;gap:12px;flex-wrap:wrap;font-size:.85rem;color:var(--tm);margin-top:6px}
+    .leaderboard-explain{margin-top:6px;font-size:.85rem;color:var(--t)}
     @media(max-width:600px){
       body{padding:8px}header{padding:12px 14px;margin-bottom:12px}.logo{font-size:1rem}.logo-i{width:32px;height:32px;font-size:.85rem}.lang-b{padding:6px 12px;font-size:.85rem}.input-s{padding:14px;margin-bottom:12px;border-radius:10px}.input-h{flex-direction:column;align-items:flex-start;gap:8px;margin-bottom:14px}.sec-t{font-size:1.05rem;width:100%}.btn-p{width:100%;text-align:center;padding:13px 20px;font-size:1rem}.ex{padding:10px;margin-bottom:14px;border-radius:8px}.ex-label{width:100%;margin-bottom:6px;font-size:.8rem}.ex-b{flex:1;min-width:0;text-align:center;padding:8px 10px;font-size:.8rem}.form-g{grid-template-columns:1fr;gap:12px}.form-r{grid-template-columns:1fr;gap:10px}.form-gr input{padding:10px 12px;font-size:1rem}.res-t{font-size:1.05rem;margin-bottom:12px}.grid{grid-template-columns:1fr;gap:12px}.card{padding:14px;border-radius:10px}.card-t{font-size:1rem;margin-bottom:12px}.metric{flex-direction:column;align-items:flex-start;gap:4px;padding:8px 0}.metric-v{justify-content:flex-start;width:100%}.score-v{font-size:2.2rem}.score-l{font-size:.85rem}.chart-c{height:220px}.spiral-chart-container{height:320px}.stage-grid{grid-template-columns:1fr}.prob-i{padding:8px 0}.prob-i div:last-child{font-size:.85rem}.quest-i{font-size:.85rem;padding:8px 0}footer{padding:16px;font-size:.8rem}.stage-grid-detail{grid-template-columns:repeat(4,1fr)}
     }
@@ -232,6 +242,21 @@
         <div id="spiralDetails"></div>
       </div>
     </div>
+
+
+      <div class="card leaderboard-section">
+        <div class="card-t" id="rankTitle">🏁 Рейтинг банков</div>
+        <div class="form-gr">
+          <label id="rankInputLabel">Массив банков (JSON или по одной JSON-строке)</label>
+          <textarea id="rankInput" class="leaderboard-input" placeholder='[{"bn":"Bank A","pg":30,"ig":10,"cc":40,"cb":35,"co2":25}]'></textarea>
+          <div class="leaderboard-note" id="rankInputHint">Поддерживается JSON-массив или несколько строк JSON (один банк на строку).</div>
+        </div>
+        <div style="margin-top:10px;display:flex;gap:8px;flex-wrap:wrap;">
+          <button class="btn-p" onclick="doRankBanks()" id="btnRank">📋 Построить рейтинг</button>
+        </div>
+        <div id="rankError" class="leaderboard-note" style="color:var(--d);display:none;margin-top:10px;"></div>
+        <div id="rankList" class="leaderboard-list"></div>
+      </div>
 
     <footer>
       <p><span id="fRepo">Репозиторий проекта:</span> <a href="https://github.com/sdtest-me/bank-welfare-analyzer" target="_blank">github.com/sdtest-me/bank-welfare-analyzer</a></p>

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -36,7 +36,9 @@
       stageMeaning:{beige:"Выживание",purple:"Традиции/Семья",red:"Неравенство/Бунт",blue:"Порядок/Дисциплина",orange:"Достижение/Средний класс",green:"Эмпатия/Взаимопомощь",yellow:"Гибкость/Адаптация",turquoise:"Холизм/Глобальность"},
       mismatchScoreLabel:"Mismatch индекс:", mismatchRiskLabel:"Уровень риска:", mismatchDriverLabel:"Главный драйвер:", esgConfidenceLabel:"Уверенность ESG:", driverConfidenceLabel:"Уверенность драйвера:", shortTermLabel:"Краткосрочное последствие:", longTermLabel:"Долгосрочное последствие:", predictiveDisclaimer:"⚠️ Сценарный прогноз: это ориентировочная оценка, а не гарантированный результат.",
       riskLevels:{low:"низкий",medium:"средний",high:"высокий"},
-      driverLabels:{redPressure:"Давление Red",empathyGap:"Разрыв эмпатии",stageMismatch:"Структурный разрыв стадий",welfareScorePenalty:"Слабый welfare score",esgClaimMismatch:"Разрыв ESG-заявлений"}
+
+      driverLabels:{redPressure:"Давление Red",empathyGap:"Разрыв эмпатии",stageMismatch:"Структурный разрыв стадий",welfareScorePenalty:"Слабый welfare score",esgClaimMismatch:"Разрыв ESG-заявлений"},
+      rankTitle:"🏁 Рейтинг банков",rankInputLabel:"Массив банков (JSON или по одной JSON-строке)",rankInputHint:"Поддерживается JSON-массив или несколько строк JSON (один банк на строку).",btnRank:"📋 Построить рейтинг",rankRisk:"Риск",rankMismatch:"Mismatch",rankEmpty:"Добавьте хотя бы один банк для сравнения.",rankParseErr:"Не удалось прочитать ввод. Используйте JSON-массив или JSON по строкам."
     },
     en: {
       app:"Bank Welfare Analyzer",inpTitle:"Bank Input Data",btnAnalyze:"🚀 Analyze",
@@ -74,7 +76,9 @@
       stageMeaning:{beige:"Survival",purple:"Traditional/Family",red:"Inequality/Rebellion",blue:"Order/Discipline",orange:"Achievement/Middle Class",green:"Empathy/Mutual Aid",yellow:"Flexible/Adaptive",turquoise:"Holistic/Global"},
       mismatchScoreLabel:"Mismatch score:", mismatchRiskLabel:"Risk level:", mismatchDriverLabel:"Primary driver:", esgConfidenceLabel:"ESG confidence:", driverConfidenceLabel:"Driver confidence:", shortTermLabel:"Short-term consequence:", longTermLabel:"Long-term consequence:", predictiveDisclaimer:"⚠️ Scenario-based projection: indicative only, not a guaranteed outcome.",
       riskLevels:{low:"low",medium:"medium",high:"high"},
-      driverLabels:{redPressure:"Red pressure",empathyGap:"Empathy gap",stageMismatch:"Structural stage gap",welfareScorePenalty:"Low welfare score",esgClaimMismatch:"ESG claim mismatch"}
+
+      driverLabels:{redPressure:"Red pressure",empathyGap:"Empathy gap",stageMismatch:"Structural stage gap",welfareScorePenalty:"Low welfare score",esgClaimMismatch:"ESG claim mismatch"},
+      rankTitle:"🏁 Bank Ranking",rankInputLabel:"Bank array input (JSON or one JSON object per line)",rankInputHint:"Supports a JSON array or newline-delimited JSON (one bank per line).",btnRank:"📋 Build ranking",rankRisk:"Risk",rankMismatch:"Mismatch",rankEmpty:"Add at least one bank to compare.",rankParseErr:"Cannot parse input. Use a JSON array or one JSON object per line."
     }
   };
 

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -34,6 +34,64 @@
     };
   }
 
+
+  function parseBanksInput(raw){
+    const text=(raw||'').trim();
+    if(!text) return [];
+
+    if(text.startsWith('[')){
+      const parsed=JSON.parse(text);
+      return Array.isArray(parsed)?parsed:[];
+    }
+
+    return text
+      .split(/\n+/)
+      .map(line=>line.trim())
+      .filter(Boolean)
+      .map(line=>JSON.parse(line));
+  }
+
+  function doRankBanks(){
+    const input=$('rankInput');
+    const err=$('rankError');
+    const list=$('rankList');
+    const t=window.i18n.tr[window.i18n.lang];
+    err.style.display='none';
+    err.textContent='';
+
+    try{
+      const banks=parseBanksInput(input.value);
+      if(!banks.length){
+        list.innerHTML='';
+        err.textContent=t.rankEmpty;
+        err.style.display='block';
+        return;
+      }
+
+      const ranked=window.analyzeMultipleBanks(banks);
+      list.innerHTML=ranked.map(item=>{
+        const name=(item.data&&item.data.bn)||'Unknown';
+        const risk=t.riskLevels[item.mismatch.riskLevel]||item.mismatch.riskLevel;
+        const snippet=(item.mismatch.explanationText && (item.mismatch.explanationText[window.i18n.lang]||item.mismatch.explanationText.en)) || '-';
+        return `<div class="leaderboard-item">
+          <div class="leaderboard-head">
+            <span class="leaderboard-rank">#${item.rank}</span>
+            <strong>${name}</strong>
+          </div>
+          <div class="leaderboard-meta">
+            <span>${t.rankRisk}: <strong>${risk}</strong></span>
+            <span>${t.rankMismatch}: <strong>${item.mismatch.mismatchScore.toFixed(2)}</strong></span>
+          </div>
+          <div class="leaderboard-explain">${snippet}</div>
+        </div>`;
+      }).join('');
+    }catch(e){
+      list.innerHTML='';
+      err.textContent=t.rankParseErr;
+      err.style.display='block';
+    }
+  }
+
   function doAnalyze(){
     const d=getData();
     const hasData=d.pg>0||d.ig>0||d.cc>0;
@@ -206,9 +264,13 @@
     window.setLang('en');
     showRes();
     ['creditConsumption','creditBusiness','creditOther'].forEach(id=>$(id).addEventListener('change',fixCredit));
+    if ($('rankInput')) {
+      $('rankInput').value = JSON.stringify([{ bn: 'Eldik Bank', pg: 208, ig: 12.9, cc: 53, cb: 20, co2: 27, pr: 25.7, im: 17, ix: 32 }, { bn: 'Balanced Bank', pg: 24, ig: 14, cc: 28, cb: 52, co2: 20, pr: 12, im: 9, ix: 14 }], null, 2);
+    }
   });
 
   window.refresh = refresh;
   window.loadEx = loadEx;
   window.doAnalyze = doAnalyze;
+  window.doRankBanks = doRankBanks;
 })();


### PR DESCRIPTION
### Motivation
- Provide a simple, visible leaderboard UI so multiple banks can be compared side-by-side in the app. 
- Accept flexible inputs (JSON array or newline-delimited JSON) and reuse existing analysis/ranking functions to produce a ranked list.

### Description
- Added leaderboard styles and a new ranking card to `index.html` with a textarea input, action button, error area and results container. 
- Implemented `parseBanksInput` and `doRankBanks` in `src/js/ui.js` which parse input, call `window.analyzeMultipleBanks`, and render each ranked entry showing rank, bank name, risk level, mismatch score, and explanation snippet. 
- Exposed `window.doRankBanks` and pre-seeded the textarea with a small sample array for quick testing. 
- Added RU/EN i18n strings in `src/js/i18n.js` for labels, hints, button text and validation messages. 
- Kept scoring, `analyzeBank`, ranking logic and core algorithms unchanged.

### Testing
- Ran syntax checks: `node --check src/js/ui.js` succeeded. 
- Ran syntax checks: `node --check src/js/i18n.js` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f269121c748324a81ffcf2972fd250)