### PR TITLE
Fix multilingual inconsistency in recommendation output

### DIFF
--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -38,6 +38,41 @@
       riskLevels:{low:"низкий",medium:"средний",high:"высокий"},
 
       driverLabels:{redPressure:"Давление Red",empathyGap:"Разрыв эмпатии",stageMismatch:"Структурный разрыв стадий",welfareScorePenalty:"Слабый welfare score",esgClaimMismatch:"Разрыв ESG-заявлений"},
+      recommendationTexts:{
+        bankDominantRedRu:"Агрессивное извлечение прибыли",
+        bankDominantOtherRu:"Развитие/Инновации",
+        bankDominantRedEn:"Aggressive Profit Extraction",
+        bankDominantOtherEn:"Development/Innovation",
+        transitionTarget:"🟠 Оранжевая",
+        gapBullets:{
+          ru:[
+            "У населения низкий {redIcon} {redStage} ({populationRed}%) — нет бунтов, люди не грабят. Но у банка высокий {bankRedStage} ({bankRed}%) — агрессивное выбивание долгов",
+            "У населения высокий {blueIcon} {blueStage} ({populationBlue}%) — дисциплинированно платят долги. Банк использует это для извлечения прибыли",
+            "Население {greenIcon} {greenStage} ({populationGreen}%) — спасается взаимовыручкой. У Банка {bankGreenStage} = {bankGreen}% (нет эмпатии к должникам)"
+          ],
+          en:[
+            "Population has low {redIcon} {redStage} ({populationRed}%) — no riots, no robberies. But Bank has high {bankRedStage} ({bankRed}%) — aggressive debt collection",
+            "Population has high {blueIcon} {blueStage} ({populationBlue}%) — disciplined debt payers. Bank exploits this for profit",
+            "Population {greenIcon} {greenStage} ({populationGreen}%) — survives through mutual aid. Bank {bankGreenStage} = {bankGreen}% (no empathy for debtors)"
+          ]
+        },
+        recommendationIntro:{
+          ru:"Банку следует перейти от {bankIcon} {bankStage} к {transitionTarget}:",
+          en:"Bank should evolve from {bankIcon} {bankStage} to {transitionTarget} by:"
+        },
+        recommendationBullets:{
+          ru:[
+            "Переход от потребительских кредитов ({creditConsumption}%) к бизнес-кредитам",
+            "Поддержка предпринимательства и экономического развития",
+            "Синхронизация роста прибыли с ростом доходов населения"
+          ],
+          en:[
+            "Shifting from consumer loans ({creditConsumption}%) to business loans",
+            "Supporting entrepreneurship & economic development",
+            "Aligning profit growth with population income growth"
+          ]
+        }
+      },
       rankTitle:"🏁 Рейтинг банков",rankInputLabel:"Массив банков (JSON или по одной JSON-строке)",rankInputHint:"Поддерживается JSON-массив или несколько строк JSON (один банк на строку).",btnRank:"📋 Построить рейтинг",rankRisk:"Риск",rankMismatch:"Mismatch",rankEmpty:"Добавьте хотя бы один банк для сравнения.",rankParseErr:"Не удалось прочитать ввод. Используйте JSON-массив или JSON по строкам."
     },
     en: {
@@ -78,6 +113,41 @@
       riskLevels:{low:"low",medium:"medium",high:"high"},
 
       driverLabels:{redPressure:"Red pressure",empathyGap:"Empathy gap",stageMismatch:"Structural stage gap",welfareScorePenalty:"Low welfare score",esgClaimMismatch:"ESG claim mismatch"},
+      recommendationTexts:{
+        bankDominantRedRu:"Агрессивное извлечение прибыли",
+        bankDominantOtherRu:"Развитие/Инновации",
+        bankDominantRedEn:"Aggressive Profit Extraction",
+        bankDominantOtherEn:"Development/Innovation",
+        transitionTarget:"🟠 Orange",
+        gapBullets:{
+          ru:[
+            "У населения низкий {redIcon} {redStage} ({populationRed}%) — нет бунтов, люди не грабят. Но у банка высокий {bankRedStage} ({bankRed}%) — агрессивное выбивание долгов",
+            "У населения высокий {blueIcon} {blueStage} ({populationBlue}%) — дисциплинированно платят долги. Банк использует это для извлечения прибыли",
+            "Население {greenIcon} {greenStage} ({populationGreen}%) — спасается взаимовыручкой. У Банка {bankGreenStage} = {bankGreen}% (нет эмпатии к должникам)"
+          ],
+          en:[
+            "Population has low {redIcon} {redStage} ({populationRed}%) — no riots, no robberies. But Bank has high {bankRedStage} ({bankRed}%) — aggressive debt collection",
+            "Population has high {blueIcon} {blueStage} ({populationBlue}%) — disciplined debt payers. Bank exploits this for profit",
+            "Population {greenIcon} {greenStage} ({populationGreen}%) — survives through mutual aid. Bank {bankGreenStage} = {bankGreen}% (no empathy for debtors)"
+          ]
+        },
+        recommendationIntro:{
+          ru:"Банку следует перейти от {bankIcon} {bankStage} к {transitionTarget}:",
+          en:"Bank should evolve from {bankIcon} {bankStage} to {transitionTarget} by:"
+        },
+        recommendationBullets:{
+          ru:[
+            "Переход от потребительских кредитов ({creditConsumption}%) к бизнес-кредитам",
+            "Поддержка предпринимательства и экономического развития",
+            "Синхронизация роста прибыли с ростом доходов населения"
+          ],
+          en:[
+            "Shifting from consumer loans ({creditConsumption}%) to business loans",
+            "Supporting entrepreneurship & economic development",
+            "Aligning profit growth with population income growth"
+          ]
+        }
+      },
       rankTitle:"🏁 Bank Ranking",rankInputLabel:"Bank array input (JSON or one JSON object per line)",rankInputHint:"Supports a JSON array or newline-delimited JSON (one bank per line).",btnRank:"📋 Build ranking",rankRisk:"Risk",rankMismatch:"Mismatch",rankEmpty:"Add at least one bank to compare.",rankParseErr:"Cannot parse input. Use a JSON array or one JSON object per line."
     }
   };
@@ -120,6 +190,11 @@
   function fmtPct(v){return (v>=0?'+':'')+v+'%';}
   function fmtNum(v){return v.toLocaleString(lang==='ru'?'ru-RU':'en-US');}
 
-  window.i18n = { tr, get lang(){ return lang; }, setLang, updateBadgeTexts, fmtPct, fmtNum };
+  function translate(key){
+    return tr[lang][key];
+  }
+
+  window.i18n = { tr, get lang(){ return lang; }, setLang, updateBadgeTexts, fmtPct, fmtNum, translate };
+  window.tr = translate;
   window.setLang = setLang;
 })();

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -103,6 +103,42 @@
     $('resultsTitle').scrollIntoView({behavior:'smooth',block:'start'});
   }
 
+  function generateRecommendations(context){
+    const lang = window.i18n.lang;
+    const t = window.tr('recommendationTexts') || {};
+    const bankDominantText = context.bankD === 'red'
+      ? (lang === 'ru' ? t.bankDominantRedRu : t.bankDominantRedEn)
+      : (lang === 'ru' ? t.bankDominantOtherRu : t.bankDominantOtherEn);
+
+    const tokens = {
+      redIcon: context.icons.red,
+      redStage: context.stages.red,
+      populationRed: context.population.red,
+      bankRedStage: context.stages.red,
+      bankRed: context.bank.red,
+      blueIcon: context.icons.blue,
+      blueStage: context.stages.blue,
+      populationBlue: context.population.blue,
+      greenIcon: context.icons.green,
+      greenStage: context.stages.green,
+      populationGreen: context.population.green,
+      bankGreenStage: context.stages.green,
+      bankGreen: context.bank.green,
+      bankIcon: context.icons[context.bankD],
+      bankStage: context.stages[context.bankD],
+      transitionTarget: t.transitionTarget,
+      creditConsumption: context.data.cc
+    };
+
+    const applyTokens = template => template.replace(/\{(\w+)\}/g, (_, key) => tokens[key]);
+    return {
+      bankDominantText,
+      gapBullets: ((t.gapBullets || {})[lang] || []).map(applyTokens),
+      recommendationIntro: applyTokens(((t.recommendationIntro || {})[lang]) || ''),
+      recommendationBullets: ((t.recommendationBullets || {})[lang] || []).map(applyTokens)
+    };
+  }
+
   function renderDetailedAnalysis(data, population, bank){
     const stages=['beige','purple','red','blue','orange','green','yellow','turquoise'];
     const icons={beige:'🟤',purple:'🟣',red:'🔴',blue:'🔵',orange:'🟠',green:'🟢',yellow:'🟡',turquoise:'💎'};
@@ -118,39 +154,24 @@
       <div class="stage-grid-detail">${stages.map(s=>`<div class="stage-cell stage-${s}">${icons[s]}<br>${population[s]}%</div>`).join('')}</div>
       <div class="dominant-text">${t.dominant} ${icons[popD]} ${t.stages[popD]} (${population[popD]}%) - ${t.stageMeaning[popD]}</div></div>`;
 
+    const rec = generateRecommendations({ data, population, bank, bankD, icons, stages: t.stages });
+
     html+=`<div><strong>🏦 ${t.bankText} (${data.bn}):</strong>
       <div class="stage-grid-detail">${stages.map(s=>`<div class="stage-cell stage-${s}">${icons[s]}<br>${bank[s]}%</div>`).join('')}</div>
-      <div class="dominant-text">${t.dominant} ${icons[bankD]} ${t.stages[bankD]} (${bank[bankD]}%) - ${bankD==='red'?(window.i18n.lang==='ru'?'Агрессивное извлечение прибыли':'Aggressive Profit Extraction'):(window.i18n.lang==='ru'?'Развитие/Инновации':'Development/Innovation')}</div></div></div>`;
+      <div class="dominant-text">${t.dominant} ${icons[bankD]} ${t.stages[bankD]} (${bank[bankD]}%) - ${rec.bankDominantText}</div></div></div>`;
 
-    if (window.i18n.lang === 'ru') {
-      html+=`<div style="margin-top:16px;padding:14px;background:#fef2f2;border-radius:8px;border-left:4px solid var(--d);">
-        <strong>${t.gapTitle}</strong><br><br>
-        • Банк ${icons[bankD]} ${t.stages[bankD]} (${bank[bankD]}%) vs Население ${icons[popD]} ${t.stages[popD]} (${population[popD]}%) = ${gapSign}${gapDiff}% разрыв<br>
-        • У населения низкий ${icons.red} ${t.stages.red} (${population.red}%) — нет бунтов, люди не грабят. Но у банка высокий ${t.stages.red} (${bank.red}%) — агрессивное выбивание долгов<br>
-        • У населения высокий ${icons.blue} ${t.stages.blue} (${population.blue}%) — дисциплинированно платят долги. Банк использует это для извлечения прибыли<br>
-        • Население ${icons.green} ${t.stages.green} (${population.green}%) — спасается взаимовыручкой. У Банка ${t.stages.green} = ${bank.green}% (нет эмпатии к должникам)</div>`;
+    const popVsBank = window.i18n.lang === 'ru'
+      ? `Банк ${icons[bankD]} ${t.stages[bankD]} (${bank[bankD]}%) vs Население ${icons[popD]} ${t.stages[popD]} (${population[popD]}%) = ${gapSign}${gapDiff}% разрыв`
+      : `Bank ${icons[bankD]} ${t.stages[bankD]} (${bank[bankD]}%) vs Population ${icons[popD]} ${t.stages[popD]} (${population[popD]}%) = ${gapSign}${gapDiff}% gap`;
+    html+=`<div style="margin-top:16px;padding:14px;background:#fef2f2;border-radius:8px;border-left:4px solid var(--d);">
+      <strong>${t.gapTitle}</strong><br><br>
+      • ${popVsBank}<br>
+      ${rec.gapBullets.map(line=>`• ${line}<br>`).join('')}</div>`;
 
-      html+=`<div style="margin-top:12px;padding:14px;background:#dcfce7;border-radius:8px;border-left:4px solid var(--s);">
-        <strong>${t.recTitle}</strong><br>
-        Банку следует перейти от ${icons[bankD]} ${t.stages[bankD]} к 🟠 Оранжевой:<br>
-        • Переход от потребительских кредитов (${data.cc}%) к бизнес-кредитам<br>
-        • Поддержка предпринимательства и экономического развития<br>
-        • Синхронизация роста прибыли с ростом доходов населения</div>`;
-    } else {
-      html+=`<div style="margin-top:16px;padding:14px;background:#fef2f2;border-radius:8px;border-left:4px solid var(--d);">
-        <strong>${t.gapTitle}</strong><br><br>
-        • Bank ${icons[bankD]} ${t.stages[bankD]} (${bank[bankD]}%) vs Population ${icons[popD]} ${t.stages[popD]} (${population[popD]}%) = ${gapSign}${gapDiff}% gap<br>
-        • Population has low ${icons.red} ${t.stages.red} (${population.red}%) — no riots, no robberies. But Bank has high ${t.stages.red} (${bank.red}%) — aggressive debt collection<br>
-        • Population has high ${icons.blue} ${t.stages.blue} (${population.blue}%) — disciplined debt payers. Bank exploits this for profit<br>
-        • Population ${icons.green} ${t.stages.green} (${population.green}%) — survives through mutual aid. Bank ${t.stages.green} = ${bank.green}% (no empathy for debtors)</div>`;
-
-      html+=`<div style="margin-top:12px;padding:14px;background:#dcfce7;border-radius:8px;border-left:4px solid var(--s);">
-        <strong>${t.recTitle}</strong><br>
-        Bank should evolve from ${icons[bankD]} ${t.stages[bankD]} to 🟠 Orange by:<br>
-        • Shifting from consumer loans (${data.cc}%) to business loans<br>
-        • Supporting entrepreneurship & economic development<br>
-        • Aligning profit growth with population income growth</div>`;
-    }
+    html+=`<div style="margin-top:12px;padding:14px;background:#dcfce7;border-radius:8px;border-left:4px solid var(--s);">
+      <strong>${t.recTitle}</strong><br>
+      ${rec.recommendationIntro}<br>
+      ${rec.recommendationBullets.map(line=>`• ${line}<br>`).join('')}</div>`;
 
     $('spiralDetails').innerHTML=html;
   }


### PR DESCRIPTION
### Motivation
- Recommendation text was rendered with scattered hardcoded branches, causing inconsistencies between RU and EN outputs. 
- Centralize recommendation copy in the i18n dictionary and expose a simple translation accessor so UI strings are generated from a single source. 
- Ensure recommendations are produced as localized strings while keeping scoring and recommendation decision logic unchanged.

### Description
- Added a `recommendationTexts` section with RU/EN templates and placeholders to `src/js/i18n.js`. 
- Introduced `i18n.translate` and global `window.tr` helper to access localized keys in `src/js/i18n.js`. 
- Implemented `generateRecommendations(context)` in `src/js/ui.js` to produce localized recommendation strings via token replacement. 
- Refactored `renderDetailedAnalysis` in `src/js/ui.js` to use `generateRecommendations` output instead of inline language branches, preserving existing scoring and recommendation structure.

### Testing
- Searched the codebase for old recommendation phrases using `rg` to confirm strings are now centralized in `src/js/i18n.js` and the search completed successfully. 
- Added and committed the modified files with `git commit`, which succeeded. 
- Verified localized templates exist for both RU and EN and that `generateRecommendations` returns localized text by inspecting updated files (manual automated searches returned expected results).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f321b33e7483248ef9a48705a76fd7)