### PR TITLE
Add impact and reputational risk layer to ranking UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,6 +267,7 @@
     <script src="src/js/core/scoring.js"></script>
     <script src="src/js/core/valueMapping.js"></script>
     <script src="src/js/core/mismatch.js"></script>
+    <script src="src/js/core/impact.js"></script>
     <script src="src/js/core/engine.js"></script>
     <script src="src/js/core/ranking.js"></script>
     <script src="src/js/core/recommendations.js"></script>

--- a/src/js/core/impact.js
+++ b/src/js/core/impact.js
@@ -1,0 +1,55 @@
+(function () {
+  const STAGES = ['beige', 'purple', 'red', 'blue', 'orange', 'green', 'yellow', 'turquoise'];
+
+  function dominantStage(stageMap) {
+    const safeMap = stageMap || {};
+    return STAGES.reduce((best, stage) => ((safeMap[stage] || 0) > (safeMap[best] || 0) ? stage : best), STAGES[0]);
+  }
+
+  function calculateImpact(result) {
+    const safeResult = result || {};
+    const mismatch = safeResult.mismatch || {};
+    const spiral = safeResult.spiral || {};
+    const prediction = mismatch.predictiveImpact || {};
+
+    const mismatchScore = Number.isFinite(mismatch.mismatchScore) ? mismatch.mismatchScore : 1;
+    const riskLevel = typeof mismatch.riskLevel === 'string' ? mismatch.riskLevel : 'high';
+
+    const bank = spiral.bank || {};
+    const population = spiral.population || {};
+
+    const bankDominant = dominantStage(bank);
+    const populationDominant = dominantStage(population);
+    const dominantGap = (bank[bankDominant] || 0) - (population[populationDominant] || 0);
+    const redGap = Math.max(0, (bank.red || 0) - (population.red || 0));
+    const greenGap = Math.max(0, (population.green || 0) - (bank.green || 0));
+    const structuralGap = STAGES.reduce((sum, stage) => sum + Math.abs((bank[stage] || 0) - (population[stage] || 0)), 0) / 2;
+
+    const impactIndex = Math.max(0, Math.min(100,
+      Math.round((mismatchScore * 65 + Math.min(structuralGap, 100) / 100 * 25 + Math.min(Math.abs(dominantGap), 40) / 40 * 10) * 100)
+    ));
+
+    let reputationalRiskKey = 'impactRiskLow';
+    if (riskLevel === 'high' || mismatchScore >= 0.67 || redGap >= 18) reputationalRiskKey = 'impactRiskHigh';
+    else if (riskLevel === 'medium' || mismatchScore >= 0.34 || redGap >= 10 || greenGap >= 10) reputationalRiskKey = 'impactRiskMedium';
+
+    return {
+      impactIndex,
+      reputationalRiskKey,
+      stageGaps: {
+        bankDominant,
+        populationDominant,
+        dominantGap: Math.round(dominantGap),
+        redGap: Math.round(redGap),
+        greenGap: Math.round(greenGap),
+        structuralGap: Math.round(structuralGap)
+      },
+      prediction: {
+        shortTerm: prediction.shortTerm || null,
+        longTerm: prediction.longTerm || null
+      }
+    };
+  }
+
+  window.calculateImpact = calculateImpact;
+})();

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -73,7 +73,7 @@
           ]
         }
       },
-      rankTitle:"🏁 Рейтинг банков",rankInputLabel:"Массив банков (JSON или по одной JSON-строке)",rankInputHint:"Поддерживается JSON-массив или несколько строк JSON (один банк на строку).",btnRank:"📋 Построить рейтинг",rankRisk:"Риск",rankMismatch:"Mismatch",rankEmpty:"Добавьте хотя бы один банк для сравнения.",rankParseErr:"Не удалось прочитать ввод. Используйте JSON-массив или JSON по строкам."
+      rankTitle:"🏁 Рейтинг банков",rankInputLabel:"Массив банков (JSON или по одной JSON-строке)",rankInputHint:"Поддерживается JSON-массив или несколько строк JSON (один банк на строку).",btnRank:"📋 Построить рейтинг",rankRisk:"Риск",rankMismatch:"Mismatch",rankEmpty:"Добавьте хотя бы один банк для сравнения.",rankParseErr:"Не удалось прочитать ввод. Используйте JSON-массив или JSON по строкам.",rankImpactTitle:"Real-world impact",rankImpactIndex:"Impact index",rankReputationRisk:"Reputational risk",rankStageGap:"Stage gap",rankShortTermImpact:"Short-term impact",rankLongTermImpact:"Long-term impact",impactRiskLow:"низкий",impactRiskMedium:"средний",impactRiskHigh:"высокий"
     },
     en: {
       app:"Bank Welfare Analyzer",inpTitle:"Bank Input Data",btnAnalyze:"🚀 Analyze",
@@ -148,7 +148,7 @@
           ]
         }
       },
-      rankTitle:"🏁 Bank Ranking",rankInputLabel:"Bank array input (JSON or one JSON object per line)",rankInputHint:"Supports a JSON array or newline-delimited JSON (one bank per line).",btnRank:"📋 Build ranking",rankRisk:"Risk",rankMismatch:"Mismatch",rankEmpty:"Add at least one bank to compare.",rankParseErr:"Cannot parse input. Use a JSON array or one JSON object per line."
+      rankTitle:"🏁 Bank Ranking",rankInputLabel:"Bank array input (JSON or one JSON object per line)",rankInputHint:"Supports a JSON array or newline-delimited JSON (one bank per line).",btnRank:"📋 Build ranking",rankRisk:"Risk",rankMismatch:"Mismatch",rankEmpty:"Add at least one bank to compare.",rankParseErr:"Cannot parse input. Use a JSON array or one JSON object per line.",rankImpactTitle:"Real-world impact",rankImpactIndex:"Impact index",rankReputationRisk:"Reputational risk",rankStageGap:"Stage gap",rankShortTermImpact:"Short-term impact",rankLongTermImpact:"Long-term impact",impactRiskLow:"low",impactRiskMedium:"medium",impactRiskHigh:"high"
     }
   };
 

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -73,6 +73,17 @@
         const name=(item.data&&item.data.bn)||'Unknown';
         const risk=t.riskLevels[item.mismatch.riskLevel]||item.mismatch.riskLevel;
         const snippet=(item.mismatch.explanationText && (item.mismatch.explanationText[window.i18n.lang]||item.mismatch.explanationText.en)) || '-';
+        const impact=typeof window.calculateImpact==='function' ? window.calculateImpact(item) : null;
+        const impactRisk=impact ? (t[impact.reputationalRiskKey] || impact.reputationalRiskKey) : '-';
+        const stageGapText=impact
+          ? `${t.stages[impact.stageGaps.bankDominant] || impact.stageGaps.bankDominant} vs ${t.stages[impact.stageGaps.populationDominant] || impact.stageGaps.populationDominant} (${impact.stageGaps.dominantGap >= 0 ? '+' : ''}${impact.stageGaps.dominantGap}pp)`
+          : '-';
+        const impactShort=impact && impact.prediction && impact.prediction.shortTerm
+          ? (impact.prediction.shortTerm[window.i18n.lang] || impact.prediction.shortTerm.en || '-')
+          : '-';
+        const impactLong=impact && impact.prediction && impact.prediction.longTerm
+          ? (impact.prediction.longTerm[window.i18n.lang] || impact.prediction.longTerm.en || '-')
+          : '-';
         const rec=typeof window.generateRecommendations==='function' ? window.generateRecommendations(item) : null;
         const shortActions=rec&&Array.isArray(rec.shortTermActions)&&rec.shortTermActions.length
           ? `<ul style="margin:6px 0 0 18px;">${rec.shortTermActions.map(a=>`<li>${a}</li>`).join('')}</ul>`
@@ -89,8 +100,16 @@
           <div class="leaderboard-meta">
             <span>${t.rankRisk}: <strong>${risk}</strong></span>
             <span>${t.rankMismatch}: <strong>${item.mismatch.mismatchScore.toFixed(2)}</strong></span>
+            <span>${t.rankImpactIndex}: <strong>${impact ? impact.impactIndex : '-'}/100</strong></span>
           </div>
           <div class="leaderboard-explain">${snippet}</div>
+          <div class="leaderboard-explain" style="margin-top:8px;">
+            <strong>${t.rankImpactTitle}</strong>
+            <div style="margin-top:4px;">${t.rankReputationRisk}: <strong>${impactRisk}</strong></div>
+            <div style="margin-top:4px;">${t.rankStageGap}: ${stageGapText}</div>
+            <div style="margin-top:6px;"><strong>${t.rankShortTermImpact}</strong><div style="margin-top:2px;">${impactShort}</div></div>
+            <div style="margin-top:6px;"><strong>${t.rankLongTermImpact}</strong><div style="margin-top:2px;">${impactLong}</div></div>
+          </div>
           <div class="leaderboard-explain" style="margin-top:8px;"><strong>Short-term actions</strong>${shortActions}</div>
           <div class="leaderboard-explain" style="margin-top:8px;"><strong>Strategic shift</strong><div style="margin-top:4px;">${strategy}</div></div>
           <div class="leaderboard-explain" style="margin-top:8px;"><strong>Risk mitigation</strong>${mitigation}</div>


### PR DESCRIPTION
### Motivation
- Provide a real-world impact and reputational-risk layer for ranked banks using existing mismatch and spiral outputs to help surface likely short/long-term consequences.
- Keep all core scoring, `analyzeBank`, and ranking logic unchanged and avoid ES module conversion.

### Description
- Added `src/js/core/impact.js` with `calculateImpact(result)` and exposed it as `window.calculateImpact`; it computes an `impactIndex` and reputational risk using `mismatch.mismatchScore`, `mismatch.riskLevel`, `mismatch.predictiveImpact`, and stage gaps derived from spiral data (dominant, red/green, structural gaps).
- Integrated impact display into the ranking UI in `src/js/ui.js` to show `Impact index`, localized reputational risk, stage-gap summary, and localized short/long-term impact snippets per ranked item.
- Extended `src/js/i18n.js` with new localization keys (`rankImpactTitle`, `rankImpactIndex`, `rankReputationRisk`, `rankStageGap`, `rankShortTermImpact`, `rankLongTermImpact`, `impactRiskLow|Medium|High`) for RU and EN.
- Included the new script in `index.html` load order without changing existing analysis/ranking flows.

### Testing
- Ran `node --check src/js/core/impact.js` and it reported no syntax errors (success).
- Ran `node --check src/js/ui.js` and `node --check src/js/i18n.js` and both reported no syntax errors (success).
- Manual smoke integration verified localized labels render and impact fields are available in ranking cards when `window.calculateImpact` is present (visual check).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3245b07dc83249374a189c7e8c93f)