### PR TITLE
Hotfix #61: prevent NaN propagation in calculateSpiralStages

### DIFF
--- a/src/js/core/scoring.js
+++ b/src/js/core/scoring.js
@@ -24,6 +24,12 @@
   }
 
   function calculateSpiralStages(data){
+    const safeData = {
+      ...data,
+      cp: Number.isFinite(data.cp) ? data.cp : 50,
+      di: Number.isFinite(data.di) ? data.di : 50,
+      co2: Number.isFinite(data.co2) ? data.co2 : 50,
+    };
     const pop={beige:0,purple:0,red:0,blue:0,orange:0,green:0,yellow:0,turquoise:0};
     const bank={beige:0,purple:0,red:0,blue:0,orange:0,green:0,yellow:0,turquoise:0};
 
@@ -49,17 +55,17 @@
 
     const profitGap = data.pg / Math.max(data.ig, 1);
     const interestSpread = Math.max(0, data.ix - data.im);
-    const capitalDiscipline = Math.max(0, Math.min(35, (data.cp * 0.22) + ((100 - data.di) * 0.18)));
-    const welfareSignal = Math.max(0, (data.ig * 1.4) + ((100 - data.pr) * 0.25) + ((100 - data.co2) * 0.16));
+    const capitalDiscipline = Math.max(0, Math.min(35, (safeData.cp * 0.22) + ((100 - safeData.di) * 0.18)));
+    const welfareSignal = Math.max(0, (data.ig * 1.4) + ((100 - data.pr) * 0.25) + ((100 - safeData.co2) * 0.16));
 
-    bank.beige = data.cp < 10 ? Math.min(28, (10 - data.cp) * 7) : 1;
-    bank.purple = Math.min(11, Math.max(2, 5 + (data.cp < 12 ? 2 : 0) - (data.cb > 35 ? 2 : 0)));
+    bank.beige = safeData.cp < 10 ? Math.min(28, (10 - safeData.cp) * 7) : 1;
+    bank.purple = Math.min(11, Math.max(2, 5 + (safeData.cp < 12 ? 2 : 0) - (data.cb > 35 ? 2 : 0)));
 
     // Stage-specific drivers with competitive amplification to create decisive peaks when signals are strong.
     const redSignal = Math.max(0, (data.cc * 0.95) + (interestSpread * 2.4) + (profitGap * 3.2) - (data.cb * 0.4) - (data.ig * 0.5));
     const orangeSignal = Math.max(0, (data.pg * 0.45) + (data.cb * 1.28) + (profitGap < 3 ? 8 : 3) - (data.cc * 0.4));
-    const blueSignal = Math.max(0, (capitalDiscipline * 2.2) + (data.cp > 35 ? 11 : 4) - (interestSpread * 0.75));
-    const greenSignal = Math.max(0, (welfareSignal * 1.5) + (data.ig * 1.35) + ((100 - data.di) * 0.3) - (data.cc * 0.45));
+    const blueSignal = Math.max(0, (capitalDiscipline * 2.2) + (safeData.cp > 35 ? 11 : 4) - (interestSpread * 0.75));
+    const greenSignal = Math.max(0, (welfareSignal * 1.5) + (data.ig * 1.35) + ((100 - safeData.di) * 0.3) - (data.cc * 0.45));
 
     const competitivePower = 1.7;
     bank.red = Math.min(38, Math.max(6, Math.pow(redSignal / 20, competitivePower) * 10 + 6));


### PR DESCRIPTION
### Motivation
- Fix a regression where using `data.co2` directly inside `calculateSpiralStages` could produce `NaN` when `co2` is missing or non-numeric, which then propagated into `welfareSignal`, `greenSignal`, and normalized stage outputs. 
- Provide a minimal hotfix that prevents NaN propagation while preserving existing formulas, coefficients, function name/signature, and normalization logic.

### Description
- Add a `safeData` object at the start of `calculateSpiralStages` that spreads `data` and uses `Number.isFinite` with a fallback of `50` for `cp`, `di`, and `co2` (keeps behavior consistent with existing cp/di handling). 
- Replace arithmetic and threshold usages in the function that previously used `data.co2` (and aligned `cp`/`di` references) to use `safeData` instead, without changing any formulas or normalization. 
- Change applied in `src/js/core/scoring.js` only, as a focused hotfix.

### Testing
- Executed a Node snippet that calls `calculateSpiralStages` with `co2` present and with `co2` missing and verified that all values in returned `population` and `bank` are finite (no `NaN`), which succeeded. 
- Verified that outputs when `co2` is present remain numerically consistent (no regression in numeric path), which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cc94e0fc8324b649680beaeec281)