### PR TITLE
Fix #50: unify Welfare and Impact into decision-grade metric with mismatch penalties

### DIFF
--- a/src/js/core/impact.js
+++ b/src/js/core/impact.js
@@ -12,7 +12,7 @@
     const spiral = safeResult.spiral || {};
     const prediction = mismatch.predictiveImpact || {};
 
-    const mismatchScore = Number.isFinite(mismatch.mismatchScore) ? mismatch.mismatchScore : 1;
+    const mismatchScore = Number.isFinite(mismatch.mismatchScore) ? mismatch.mismatchScore : 0;
     const riskLevel = typeof mismatch.riskLevel === 'string' ? mismatch.riskLevel : 'high';
 
     const bank = spiral.bank || {};
@@ -20,14 +20,22 @@
 
     const bankDominant = dominantStage(bank);
     const populationDominant = dominantStage(population);
-    const dominantGap = (bank[bankDominant] || 0) - (population[populationDominant] || 0);
+    const computedDominantGap = (bank[bankDominant] || 0) - (population[populationDominant] || 0);
+    const dominantGap = Number.isFinite(mismatch.dominantStageGap) ? Math.abs(mismatch.dominantStageGap) : Math.abs(computedDominantGap);
     const redGap = Math.max(0, (bank.red || 0) - (population.red || 0));
     const greenGap = Math.max(0, (population.green || 0) - (bank.green || 0));
     const structuralGap = STAGES.reduce((sum, stage) => sum + Math.abs((bank[stage] || 0) - (population[stage] || 0)), 0) / 2;
 
-    const impactIndex = Math.max(0, Math.min(100,
-      Math.round((mismatchScore * 65 + Math.min(structuralGap, 100) / 100 * 25 + Math.min(Math.abs(dominantGap), 40) / 40 * 10) * 100)
-    ));
+    const baseImpact = safeResult.welfareIndex || safeResult.score || 50;
+    let mismatchPenalty = mismatchScore * 40;
+    if (mismatchScore > 0.35) mismatchPenalty *= 1.2;
+
+    const stagePenalty = dominantGap * 0.8;
+    const redPenalty = redGap * 0.6;
+    const greenPenalty = greenGap * 0.4;
+
+    const impactRaw = baseImpact - mismatchPenalty - stagePenalty - redPenalty - greenPenalty;
+    const impactIndex = Math.round(Math.max(0, Math.min(100, impactRaw)));
 
     let reputationalRiskKey = 'impactRiskLow';
     if (riskLevel === 'high' || mismatchScore >= 0.67 || redGap >= 18) reputationalRiskKey = 'impactRiskHigh';
@@ -39,7 +47,7 @@
       stageGaps: {
         bankDominant,
         populationDominant,
-        dominantGap: Math.round(dominantGap),
+        dominantGap: Math.round(computedDominantGap),
         redGap: Math.round(redGap),
         greenGap: Math.round(greenGap),
         structuralGap: Math.round(structuralGap)


### PR DESCRIPTION
### Motivation
- Replace the legacy impact formula with a single decision-grade metric that starts from the Country Welfare contribution and subtracts explicit mismatch and stage-gap penalties.
- Ensure impact reflects available welfare signals (`welfareIndex`/`score`) and that high mismatch reduces impact significantly.
- Remove legacy behaviour that could force uniform/decoupled impact values and make impact insensitive to mismatch.

### Description
- Updated `calculateImpact(result)` in `src/js/core/impact.js` to derive `baseImpact` from `safeResult.welfareIndex || safeResult.score || 50` and compute `impactIndex` from that baseline. 
- Changed default mismatch fallback to `0` and added penalties: `mismatchPenalty = mismatchScore * 40` with a `*1.2` multiplier when `mismatchScore > 0.35`, `stagePenalty = dominantGap * 0.8`, `redPenalty = redGap * 0.6`, and `greenPenalty = greenGap * 0.4`.
- Clamped the final impact to `[0, 100]` and rounded it, kept the original return shape (including `reputationalRiskKey` and `prediction`), and preserved `window.calculateImpact` export and function name.
- Reused computed dominant gap for display (`stageGaps.dominantGap`) while using `mismatch.dominantStageGap` when present for penalty computation.

### Testing
- Ran a local automated node VM scenario that loads `scoring`, `valueMapping`, `mismatch`, `impact`, and `engine` modules and executed a 5-bank dataset via `node` to exercise `window.analyzeBank` + `window.calculateImpact`; the run completed successfully and produced varied `impactIndex` values across banks.
- Verified the outputs showed lower impact for banks with higher mismatch and that impacts are not universally `100` (behaviour matches the expected outcomes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f85e9be97483249bdeff26c4393759)