### PR TITLE
Fix #65: preserve zero welfare values in baseImpact fallback

### DIFF
--- a/src/js/core/impact.js
+++ b/src/js/core/impact.js
@@ -12,6 +12,13 @@
     const spiral = safeResult.spiral || {};
     const prediction = mismatch.predictiveImpact || {};
 
+    const baseImpact =
+      Number.isFinite(safeResult.welfareIndex)
+        ? safeResult.welfareIndex
+        : Number.isFinite(safeResult.score)
+          ? safeResult.score
+          : 50;
+
     const mismatchScore = Number.isFinite(mismatch.mismatchScore) ? mismatch.mismatchScore : 1;
     const riskLevel = typeof mismatch.riskLevel === 'string' ? mismatch.riskLevel : 'high';
 


### PR DESCRIPTION
### Motivation
- Fix a bug where `0` values for `welfareIndex` or `score` were treated as falsy by the `||` fallback and replaced with `50`, so zero welfare should be preserved and only non-finite values should trigger the fallback.

### Description
- In `src/js/core/impact.js` updated `calculateImpact` to compute `baseImpact` with explicit `Number.isFinite` checks (`Number.isFinite(safeResult.welfareIndex) ? safeResult.welfareIndex : Number.isFinite(safeResult.score) ? safeResult.score : 50;`) so that `0` is preserved and only `undefined`, `null`, or `NaN` fall back to `50`.

### Testing
- Ran a Node-based smoke test that loaded `src/js/core/impact.js` and invoked `calculateImpact` with representative cases including `welfareIndex: 0` and `score: 0`, which confirmed no `NaN` outputs (`hasNaN false`) and returned impact indices, so automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8626fb78883248695121a1678abe5)