### PR TITLE
calculateImpact: switch to multiplicative penalty model and clamp outputs

### DIFF
--- a/src/js/core/impact.js
+++ b/src/js/core/impact.js
@@ -31,9 +31,16 @@
     const redGap = Math.max(0, (bank.red || 0) - (population.red || 0));
     const greenGap = Math.max(0, (population.green || 0) - (bank.green || 0));
     const structuralGap = STAGES.reduce((sum, stage) => sum + Math.abs((bank[stage] || 0) - (population[stage] || 0)), 0) / 2;
+    const redPenalty = (bank.red || 0) > 25 ? 0.15 : 0;
+    const dominantGapPenalty = Math.min(Math.abs(dominantGap) / 40, 1);
+    const penalty = Math.min(0.9,
+      0.6 * mismatchScore +
+      0.25 * dominantGapPenalty +
+      0.15 * redPenalty
+    );
 
     const impactIndex = Math.max(0, Math.min(100,
-      Math.round((mismatchScore * 65 + Math.min(structuralGap, 100) / 100 * 25 + Math.min(Math.abs(dominantGap), 40) / 40 * 10) * 100)
+      Math.round(baseImpact * (1 - penalty))
     ));
 
     let reputationalRiskKey = 'impactRiskLow';


### PR DESCRIPTION
### Motivation
- Move the impact calculation from an additive index to a multiplicative penalty model so penalties proportionally reduce a base impact and avoid constant 100 outputs.
- Encode a clear, tunable penalty breakdown (mismatch, dominant gap, red share) to make impacts vary across the dataset and remain numeric-safe.

### Description
- Replaced the previous additive scoring with `impact = baseImpact * (1 - penalty)` while preserving the function signature and `window.calculateImpact` export.
- Implemented `penalty` as `0.6 * mismatchScore + 0.25 * Math.min(Math.abs(dominantGap)/40, 1) + 0.15 * redPenalty` where `redPenalty` is `0.15` when `(bank.red || 0) > 25` and `0` otherwise.
- Clamped `penalty` to a maximum of `0.9` and clamped final `impactIndex` into the `[0, 100]` range; preserved existing `structuralGap` output and reputational risk logic.
- Left all existing text outputs and object shape unchanged so downstream consumers remain compatible.

### Testing
- Searched code references for `calculateImpact`, `mismatchScore`, `dominantGap`, and `redPenalty` with `rg` to confirm usage locations and that the new symbols are present, and the command completed successfully.
- Inspected `src/js/core/impact.js` with `sed`/`nl` to verify the new penalty computation and the clamped `impactIndex`, and the file reflected the expected changes.
- Executed the automated edit script used to apply the change and verified the modified file content, with all commands returning success.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a958cb448324b3d4e9b07f0b2e6c)