### PR TITLE
Adjust impact penalty and post-penalty scaling in calculateImpact

### DIFF
--- a/src/js/core/impact.js
+++ b/src/js/core/impact.js
@@ -27,21 +27,32 @@
 
     const bankDominant = dominantStage(bank);
     const populationDominant = dominantStage(population);
-    const dominantGap = (bank[bankDominant] || 0) - (population[populationDominant] || 0);
-    const redGap = Math.max(0, (bank.red || 0) - (population.red || 0));
-    const greenGap = Math.max(0, (population.green || 0) - (bank.green || 0));
-    const structuralGap = STAGES.reduce((sum, stage) => sum + Math.abs((bank[stage] || 0) - (population[stage] || 0)), 0) / 2;
-    const redPenalty = (bank.red || 0) > 25 ? 0.15 : 0;
-    const dominantGapPenalty = Math.min(Math.abs(dominantGap) / 40, 1);
-    const penalty = Math.min(0.9,
-      0.6 * mismatchScore +
-      0.25 * dominantGapPenalty +
-      0.15 * redPenalty
-    );
+    const toFinite = (value) => (Number.isFinite(value) ? value : 0);
+    const dominantGap = toFinite(bank[bankDominant]) - toFinite(population[populationDominant]);
+    const redGap = Math.max(0, toFinite(bank.red) - toFinite(population.red));
+    const greenGap = Math.max(0, toFinite(population.green) - toFinite(bank.green));
+    const structuralGap = STAGES.reduce((sum, stage) => sum + Math.abs(toFinite(bank[stage]) - toFinite(population[stage])), 0) / 2;
 
-    const impactIndex = Math.max(0, Math.min(100,
-      Math.round(baseImpact * (1 - penalty))
-    ));
+    const heavyMismatch = Math.pow(mismatchScore, 1.4);
+    const gapPenalty = Math.min(Math.abs(dominantGap) / 40, 1);
+    const redPenalty = Math.min(toFinite(bank.red) / 40, 1) * 0.2;
+
+    let penalty =
+      0.55 * heavyMismatch +
+      0.25 * gapPenalty +
+      0.20 * redPenalty;
+
+    penalty = Math.min(penalty, 0.9);
+
+    let impact = baseImpact * (1 - penalty);
+
+    if (mismatchScore > 0.35) {
+      impact *= 0.8;
+    }
+
+    impact = Math.min(impact, baseImpact + 10);
+
+    const impactIndex = Math.max(0, Math.min(100, Math.round(impact)));
 
     let reputationalRiskKey = 'impactRiskLow';
     if (riskLevel === 'high' || mismatchScore >= 0.67 || redGap >= 18) reputationalRiskKey = 'impactRiskHigh';


### PR DESCRIPTION
### Motivation
- Replace the previous linear penalty model with a heavier-weighted mismatch term and explicit gap/red contributions to better reflect observed impact drivers.
- Ensure calculations remain stable when stage fields are missing or non-finite to avoid `NaN` propagation and inconsistent outputs.
- Apply a post-penalty scaling rule for moderate-to-high mismatch scores and cap impact growth relative to `baseImpact`.

### Description
- Replaced penalty computation in `src/js/core/impact.js` to use `heavyMismatch = Math.pow(mismatchScore, 1.4)`, `gapPenalty`, and a scaled `redPenalty`, then capped `penalty` at `0.9`.
- Added `toFinite` normalization for numeric reads from `bank` and `population` to keep missing/non-finite fields from producing `NaN` in gap and structural calculations.
- Replaced impact flow to compute `impact = baseImpact * (1 - penalty)`, apply an extra `0.8` multiplier when `mismatchScore > 0.35`, then cap `impact` to `baseImpact + 10` and clamp/round into `[0, 100]` as `impactIndex`.
- Preserved the existing `baseImpact` finite fallback logic, function signature, export binding `window.calculateImpact`, and output keys/text such as `impactRiskLow/Medium/High`.

### Testing
- Verified the updated file with `sed -n '1,220p' src/js/core/impact.js` and `nl -ba src/js/core/impact.js` to confirm the new logic was written to disk successfully.
- Committed the change via `git commit` which completed successfully.
- Performed a static review of the updated math and clamps which confirmed there is no obvious `NaN` propagation and outputs are bounded.
- No unit tests were executed as part of this change (no automated test suite was run in this rollout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8ebd593b48324ac8a640fea3e3f77)