### PR TITLE
Adjust impact calibration: increase mismatch sensitivity and structural pressure

### DIFF
--- a/src/js/core/impact.js
+++ b/src/js/core/impact.js
@@ -26,7 +26,7 @@
 
     const mismatchScore = Number.isFinite(mismatch.mismatchScore) ? mismatch.mismatchScore : 1;
     const safeMismatch = Math.max(0, Math.min(1, toFinite(mismatchScore)));
-    const heavyMismatch = Math.pow(safeMismatch, 1.4);
+    const heavyMismatch = Math.pow(safeMismatch, 1.5);
     const riskLevel = typeof mismatch.riskLevel === 'string' ? mismatch.riskLevel : 'high';
 
     const bank = spiral.bank || {};
@@ -40,14 +40,17 @@
     const structuralGap = STAGES.reduce((sum, stage) => sum + Math.abs((bank[stage] || 0) - (population[stage] || 0)), 0) / 2;
     const redPenalty = (bank.red || 0) > 25 ? 0.15 : 0;
     const dominantGapPenalty = Math.min(Math.abs(dominantGap) / 40, 1);
+    const structuralGapPenalty = Math.min(structuralGap / 100, 1);
     const penalty = Math.min(0.9,
       0.6 * heavyMismatch +
       0.25 * dominantGapPenalty +
-      0.15 * redPenalty
+      0.15 * redPenalty +
+      0.11 * structuralGapPenalty
     );
+    const mismatchPressure = safeMismatch > 0.30 ? 0.9 : 1;
 
     const impactIndex = Math.max(0, Math.min(100,
-      Math.round(baseImpact * (1 - penalty))
+      Math.round(baseImpact * (1 - penalty) * mismatchPressure)
     ));
 
     let reputationalRiskKey = 'impactRiskLow';


### PR DESCRIPTION
### Motivation
- Increase sensitivity to mismatch so higher mismatch values reduce impact more strongly.
- Slightly boost structural divergence influence within the existing penalty composition without changing framework shape.
- Add a soft lower-bound pressure to nudge impacts down when mismatch is meaningfully present while preserving current fallbacks.

### Description
- Raised `heavyMismatch` exponent from `1.4` to `1.5` to increase mismatch sensitivity. 
- Added `structuralGapPenalty = Math.min(structuralGap / 100, 1)` and included it in `penalty` with a `0.11` weight to increase structural influence by ~10–15% inside the existing penalty composition. 
- Applied a soft multiplier `mismatchPressure = safeMismatch > 0.30 ? 0.9 : 1` and multiplied it into the final impact calculation as an additional lower-bound pressure. 
- Preserved `baseImpact` fallback logic, the overall penalty framework, exports (`window.calculateImpact`), and existing helpers (`toFinite`, `safeMismatch` flow). 

### Testing
- Ran a Node-based runtime check that loaded `src/js/core/impact.js` and invoked `calculateImpact` with representative scenarios, and verified no `NaN` values were produced and outputs were finite (observed `impactIndex` values: `49`, `32`, `20`, `21`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f258182483248f4cc2059a8fd86c)