### PR TITLE
Fix mismatchPressure to apply only when mismatchScore is present

### DIFF
--- a/src/js/core/impact.js
+++ b/src/js/core/impact.js
@@ -24,6 +24,7 @@
         ? safeResult.score
         : 50;
 
+    const hasMismatch = Number.isFinite(result?.mismatchScore);
     const mismatchScore = Number.isFinite(mismatch.mismatchScore) ? mismatch.mismatchScore : 1;
     const safeMismatch = Math.max(0, Math.min(1, toFinite(mismatchScore)));
     const heavyMismatch = Math.pow(safeMismatch, 1.4);
@@ -46,8 +47,11 @@
       0.15 * redPenalty
     );
 
+    const mismatchPressure =
+      hasMismatch && safeMismatch > 0.30 ? 0.9 : 1;
+
     const impactIndex = Math.max(0, Math.min(100,
-      Math.round(baseImpact * (1 - penalty))
+      Math.round(baseImpact * (1 - penalty) * mismatchPressure)
     ));
 
     let reputationalRiskKey = 'impactRiskLow';


### PR DESCRIPTION
### Motivation
- Ensure the `mismatchPressure` adjustment is only applied when a valid `mismatchScore` is present so the impact calculation does not unintentionally reduce `impactIndex` when mismatch data is missing.

### Description
- Add a presence guard `const hasMismatch = Number.isFinite(result?.mismatchScore);`, introduce `const mismatchPressure = hasMismatch && safeMismatch > 0.30 ? 0.9 : 1;` and update the final formula to `Math.round(baseImpact * (1 - penalty) * mismatchPressure)` while leaving the `penalty` structure, `baseImpact` logic, exports, and rounding/clamping unchanged.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9af34bb2083249f3597088b293c29)