### PR TITLE
Apply final risk override before ranking

### DIFF
--- a/src/js/core/ranking.js
+++ b/src/js/core/ranking.js
@@ -22,6 +22,32 @@
     };
   }
 
+  function normalizeImpactRiskKey(key) {
+    if (key === 'impactRiskHigh') return 'high';
+    if (key === 'impactRiskMedium') return 'medium';
+    return 'low';
+  }
+
+  function applyFinalRiskOverride(item) {
+    const comparable = toComparableResult(item);
+    const impact = typeof window.calculateImpact === 'function'
+      ? window.calculateImpact(comparable)
+      : null;
+
+    if (!impact) {
+      return comparable;
+    }
+
+    return {
+      ...comparable,
+      mismatch: {
+        ...comparable.mismatch,
+        riskLevel: normalizeImpactRiskKey(impact.reputationalRiskKey)
+      },
+      impact
+    };
+  }
+
   function rankBanks(resultsArray) {
     const safeResults = Array.isArray(resultsArray) ? resultsArray : [];
 
@@ -33,6 +59,13 @@
       .sort((a, b) => {
         const riskDelta = riskPriority[a.analyzed.mismatch.riskLevel] - riskPriority[b.analyzed.mismatch.riskLevel];
         if (riskDelta !== 0) return riskDelta;
+
+        const aImpact = Number(a.analyzed.impact && a.analyzed.impact.impactIndex);
+        const bImpact = Number(b.analyzed.impact && b.analyzed.impact.impactIndex);
+        const safeAImpact = Number.isFinite(aImpact) ? aImpact : 0;
+        const safeBImpact = Number.isFinite(bImpact) ? bImpact : 0;
+        const impactDelta = safeBImpact - safeAImpact;
+        if (impactDelta !== 0) return impactDelta;
 
         const mismatchDelta = a.analyzed.mismatch.mismatchScore - b.analyzed.mismatch.mismatchScore;
         if (mismatchDelta !== 0) return mismatchDelta;
@@ -48,9 +81,11 @@
   function analyzeMultipleBanks(banksArray) {
     const safeBanks = Array.isArray(banksArray) ? banksArray : [];
     const analyzed = safeBanks.map((bank) => window.analyzeBank(bank));
-    return rankBanks(analyzed);
+    const withFinalRisk = analyzed.map((result) => applyFinalRiskOverride(result));
+    return rankBanks(withFinalRisk);
   }
 
   window.rankBanks = rankBanks;
   window.analyzeMultipleBanks = analyzeMultipleBanks;
+  window.applyFinalRiskOverride = applyFinalRiskOverride;
 })();


### PR DESCRIPTION
### Motivation
- Ranking previously used pre-override mismatch values which caused inconsistent ordering when `calculateImpact` produced a different final risk signal. 
- Ensure final `impactIndex` and the overridden risk level govern ordering so results reflect the complete analysis. 
- Prevent any post-ranking mutation of risk that could change ranks after sorting. 

### Description
- Added `normalizeImpactRiskKey` and `applyFinalRiskOverride` in `src/js/core/ranking.js` to compute final impact and map `reputationalRiskKey` into a `mismatch.riskLevel` override. 
- `analyzeMultipleBanks` now runs `analyzeBank` for each item, then applies `applyFinalRiskOverride` to each analyzed result, and only then calls `rankBanks`. 
- `rankBanks` sorting precedence was updated to use overridden `mismatch.riskLevel` first, then final `impact.impactIndex` (higher impact ranks earlier), then `mismatch.mismatchScore`, then original index for stable tie-breaking. 
- Exported `window.applyFinalRiskOverride` and preserved the original output shape and left `calculateImpact` unchanged. 

### Testing
- Ran `node --check src/js/core/ranking.js` to validate the modified file parsed without syntax errors, and it succeeded. 
- Performed basic repository checks to confirm the updated file is present and loadable, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e3a8fd748324b6f24b55e0ac2a71)