### PR TITLE
Prioritize impactIndex in bank ranking (impact-first comparator)

### DIFF
--- a/src/js/core/ranking.js
+++ b/src/js/core/ranking.js
@@ -57,9 +57,6 @@
         analyzed: toComparableResult(result)
       }))
       .sort((a, b) => {
-        const riskDelta = riskPriority[a.analyzed.mismatch.riskLevel] - riskPriority[b.analyzed.mismatch.riskLevel];
-        if (riskDelta !== 0) return riskDelta;
-
         const aImpact = Number(a.analyzed.impact && a.analyzed.impact.impactIndex);
         const bImpact = Number(b.analyzed.impact && b.analyzed.impact.impactIndex);
         const safeAImpact = Number.isFinite(aImpact) ? aImpact : 0;
@@ -69,6 +66,9 @@
 
         const mismatchDelta = a.analyzed.mismatch.mismatchScore - b.analyzed.mismatch.mismatchScore;
         if (mismatchDelta !== 0) return mismatchDelta;
+
+        const riskDelta = riskPriority[a.analyzed.mismatch.riskLevel] - riskPriority[b.analyzed.mismatch.riskLevel];
+        if (riskDelta !== 0) return riskDelta;
 
         return a.originalIndex - b.originalIndex;
       })


### PR DESCRIPTION
### Motivation

- Ensure ranking gives precedence to real-world impact so `impactIndex` determines order before risk, per Issue #85. 
- Prevent `riskLevel` from overriding impact-based ordering while preserving the existing final risk override behavior. 

### Description

- Updated the comparator in `rankBanks` (`src/js/core/ranking.js`) to sort by `impactIndex` (descending) first, then `mismatchScore`, then `riskLevel`, and finally `originalIndex` as the stable tiebreaker. 
- Moved the `riskLevel` comparison after `impactIndex` and `mismatchScore` to ensure impact-first ordering. 
- Left `applyFinalRiskOverride` and the final reputational risk mapping into `mismatch.riskLevel` unchanged. 
- Did not modify `calculateImpact` and preserved the output shape returned by `rankBanks` (`{ rank, ...entry.analyzed }`).

### Testing

- Ran the automated test command `npm test`, which exited with code 254 indicating the test run failed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e85299d48324b692cc424c4dbb97)