### PR TITLE
Handle missing impactIndex when selecting recommendation tier

### DIFF
--- a/src/js/core/recommendations.js
+++ b/src/js/core/recommendations.js
@@ -42,10 +42,10 @@
 
     const rawImpact = (safeResult.impact || {}).impactIndex;
 
-const impactIndex =
-  rawImpact === null || rawImpact === undefined || rawImpact === ''
-    ? null
-    : Number(rawImpact);
+    const impactIndex =
+      rawImpact === null || rawImpact === undefined || rawImpact === ''
+        ? null
+        : Number(rawImpact);
     const hasImpact = Number.isFinite(impactIndex);
 
     const tieredStrategicRecommendation = !hasImpact

--- a/src/js/core/recommendations.js
+++ b/src/js/core/recommendations.js
@@ -40,6 +40,17 @@
       purple: 'Transition from tradition-driven patterns to transparent, data-backed lending governance.'
     };
 
+    const impactIndex = Number((safeResult.impact || {}).impactIndex);
+    const hasImpact = Number.isFinite(impactIndex);
+
+    const tieredStrategicRecommendation = !hasImpact
+      ? 'Maintain a balanced transition posture until impact data is available, then align actions to measured borrower outcomes.'
+      : impactIndex > 70
+        ? 'Stable alignment detected: reinforce current strategy with disciplined monitoring and incremental borrower-outcome improvements.'
+        : impactIndex >= 50
+          ? 'Transitional alignment detected: prioritize targeted portfolio adjustments to improve welfare alignment and execution consistency.'
+          : 'Structural risk detected: execute a structural-risk correction plan focused on affordability, governance, and stage-realignment.';
+
     const riskMitigation = [];
     if (esgAlignmentGap >= 20) {
       riskMitigation.push('High ESG alignment gap detected: institute quarterly audit of promised ESG outcomes vs borrower experience.');
@@ -63,7 +74,7 @@
       strategicShift: {
         dominantBankStage: bankDominant,
         dominantPopulationStage: populationDominant,
-        recommendation: strategicByStage[bankDominant] || strategicByStage.orange
+        recommendation: `${strategicByStage[bankDominant] || strategicByStage.orange} ${tieredStrategicRecommendation}`
       },
       riskMitigation
     };

--- a/src/js/core/recommendations.js
+++ b/src/js/core/recommendations.js
@@ -40,7 +40,12 @@
       purple: 'Transition from tradition-driven patterns to transparent, data-backed lending governance.'
     };
 
-    const impactIndex = Number((safeResult.impact || {}).impactIndex);
+    const rawImpact = (safeResult.impact || {}).impactIndex;
+
+const impactIndex =
+  rawImpact === null || rawImpact === undefined || rawImpact === ''
+    ? null
+    : Number(rawImpact);
     const hasImpact = Number.isFinite(impactIndex);
 
     const tieredStrategicRecommendation = !hasImpact


### PR DESCRIPTION
### Motivation
- Prevent recommendation logic from falling through to a worst-case tier when `impactIndex` is missing or non-numeric. 
- Make tier selection deterministic and explicit based on the presence and numeric value of `impactIndex`. 
- Preserve existing function signature and output shape while avoiding accidental behavioral changes in other impact calculations.

### Description
- Extract `impactIndex` from the safe result with `const impactIndex = Number((safeResult.impact || {}).impactIndex);` and add a presence guard `const hasImpact = Number.isFinite(impactIndex);`. 
- Introduce `tieredStrategicRecommendation` with ordered selection: no impact (neutral/default), `impactIndex > 70` (stable alignment), `impactIndex >= 50` (transitional), otherwise (structural-risk). 
- Append the tiered recommendation to the existing `strategicShift.recommendation` without changing the return keys or function signature. 
- No changes made to `calculateImpact` or other impact-calculation logic.

### Testing
- Ran `node --check src/js/core/recommendations.js` to verify syntax; the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f1bd5ebc83249c0cc09ea08659f2)