### PR TITLE
Add impact engine prompt specification v1

### DIFF
--- a/prompts/core/impact-engine-v1.md
+++ b/prompts/core/impact-engine-v1.md
@@ -1,0 +1,131 @@
+# Impact Engine v1
+
+## Purpose
+
+Define the logic for interpreting bank welfare impact through behavioral, structural, and socio-economic indicators.
+
+The engine converts raw banking and population indicators into a decision-grade Impact Index.
+
+---
+
+# Core Variables
+
+The model evaluates:
+
+- mismatchScore
+- ESG alignment
+- credit structure
+- dominant stage conflicts
+- poverty pressure
+- affordability pressure
+- behavioral extraction patterns
+
+---
+
+# Impact Index Philosophy
+
+The Impact Index is NOT:
+
+- a profitability metric
+- a shareholder performance metric
+- a credit-rating replacement
+
+The Impact Index IS:
+
+- a socio-behavioral alignment indicator
+- a welfare-system pressure indicator
+- a systemic sustainability signal
+
+---
+
+# Impact Tiers
+
+## Stable Alignment
+
+Condition:
+- impactIndex > 70
+
+Meaning:
+- banking behavior is relatively aligned with population conditions
+- extraction pressure is limited
+- institutional stability is likely sustainable
+
+Narrative characteristics:
+- disciplined monitoring
+- incremental optimization
+- calibration maintenance
+
+---
+
+## Transitional Alignment
+
+Condition:
+- impactIndex >= 50
+
+Meaning:
+- partial structural mismatch exists
+- institutional drift may be developing
+- corrective adaptation is required
+
+Narrative characteristics:
+- portfolio adjustment
+- communication recalibration
+- targeted corrective actions
+
+---
+
+## Structural Risk
+
+Condition:
+- impactIndex < 50
+
+Meaning:
+- structural extraction pressure exists
+- mismatch is likely systemic
+- long-term welfare deterioration risk increases
+
+Narrative characteristics:
+- governance intervention
+- affordability restructuring
+- behavioral realignment
+- systemic correction
+
+---
+
+# Calibration Rules
+
+The engine should:
+
+- produce meaningful separation between banks
+- avoid score compression
+- avoid excessive clustering near baseline values
+- preserve narrative differentiation
+
+---
+
+# Missing Data Handling
+
+If:
+- impactIndex is null
+- impactIndex is undefined
+- impactIndex is empty
+
+Then:
+- avoid structural-risk escalation
+- produce neutral uncertainty-aware guidance
+
+---
+
+# Narrative Constraints
+
+Avoid:
+- deterministic predictions
+- unsupported causality
+- political framing
+- moral judgment language
+
+Prefer:
+- probabilistic interpretation
+- systems framing
+- uncertainty disclosure
+- structural analysis


### PR DESCRIPTION
## Summary

Add versioned impact engine specification.

Defines:
- impactIndex interpretation
- calibration assumptions
- mismatch influence logic
- welfare alignment scoring behavior
- narrative thresholds for impact severity

This creates the first formalized impact-calculation governance layer.