### PR TITLE
Add risk engine prompt specification v1

### DIFF
--- a/prompts/core/risk-engine-v1.md
+++ b/prompts/core/risk-engine-v1.md
@@ -1,0 +1,133 @@
+# Risk Engine v1
+
+## Purpose
+
+Define systemic, reputational, and behavioral risk interpretation logic for bank-population mismatch analysis.
+
+The engine translates structural conditions into decision-grade risk narratives.
+
+---
+
+# Core Risk Dimensions
+
+The model evaluates:
+
+- mismatchScore
+- impactIndex
+- dominant stage conflict
+- ESG alignment gap
+- affordability pressure
+- extraction intensity
+- uncertainty level
+
+---
+
+# Risk Philosophy
+
+Risk is interpreted as:
+
+- systemic instability risk
+- institutional mismatch risk
+- borrower-pressure risk
+- reputational exposure risk
+
+The model does NOT evaluate:
+- insolvency probability
+- market valuation
+- shareholder return potential
+
+---
+
+# Global Risk Tiers
+
+## Low Risk
+
+Condition:
+- mismatchScore < 0.20
+- impactIndex > 70
+
+Meaning:
+- structural alignment is relatively stable
+- extraction pressure is limited
+- institutional adaptation is functioning
+
+Narrative characteristics:
+- preventive monitoring
+- calibration maintenance
+- incremental improvement
+
+---
+
+## Moderate Risk
+
+Condition:
+- mismatchScore >= 0.20
+- impactIndex >= 50
+
+Meaning:
+- institutional drift may be developing
+- alignment inconsistencies exist
+- localized borrower pressure may increase
+
+Narrative characteristics:
+- targeted intervention
+- policy adjustment
+- execution recalibration
+
+---
+
+## High Risk
+
+Condition:
+- mismatchScore >= 0.35
+- impactIndex < 50
+
+Meaning:
+- structural extraction pressure is likely active
+- mismatch may become self-reinforcing
+- reputational and systemic exposure increase
+
+Narrative characteristics:
+- structural correction
+- governance intervention
+- affordability stabilization
+- portfolio redesign
+
+---
+
+# Consistency Rules
+
+The engine should:
+
+- avoid low-risk narratives when impact is structurally weak
+- avoid severe escalation under high uncertainty
+- preserve alignment between impact, risk, and recommendations
+
+---
+
+# Missing Data Handling
+
+If:
+- impactIndex is unavailable
+- mismatchScore is unavailable
+
+Then:
+- reduce escalation confidence
+- avoid deterministic risk narratives
+- produce uncertainty-aware interpretation
+
+---
+
+# Narrative Constraints
+
+Avoid:
+- panic framing
+- deterministic collapse language
+- unsupported accusations
+- political interpretation
+
+Prefer:
+- probabilistic language
+- systemic framing
+- institutional analysis
+- uncertainty disclosure


### PR DESCRIPTION
## Summary

Add versioned risk engine specification.

Defines:
- global risk tier logic
- mismatch escalation behavior
- reputational and systemic risk framing
- uncertainty-aware risk interpretation
- consistency constraints between impact and risk narratives

This establishes a traceable risk-classification prompt layer.