### PR TITLE
Add structural risk narrative template v1

### DIFF
--- a/prompts/narratives/structural-risk-v1.md
+++ b/prompts/narratives/structural-risk-v1.md
@@ -1,0 +1,91 @@
+# Structural Risk Narrative v1
+
+## Purpose
+
+Provide reusable narrative templates for high-risk structural mismatch conditions.
+
+This narrative layer separates language generation from scoring logic.
+
+---
+
+# Structural Risk Interpretation
+
+Structural risk indicates that:
+
+- borrower pressure may be systemically reinforced
+- institutional incentives may reward extraction patterns
+- long-term welfare alignment may deteriorate
+- mismatch may become self-reinforcing
+
+---
+
+# Narrative Characteristics
+
+Preferred tone:
+- analytical
+- systemic
+- uncertainty-aware
+- institution-focused
+
+Avoid:
+- sensationalism
+- panic language
+- deterministic collapse framing
+- political accusations
+
+---
+
+# Recommended Narrative Components
+
+## Institutional Mismatch
+
+Describe:
+- divergence between bank behavior and population conditions
+- misalignment between incentives and welfare outcomes
+
+---
+
+## Borrower Pressure
+
+Describe:
+- affordability strain
+- communication friction
+- extraction pressure
+- repayment instability
+
+---
+
+## Governance Risk
+
+Describe:
+- weak adaptation capacity
+- rigid portfolio incentives
+- insufficient welfare alignment monitoring
+
+---
+
+## Long-Term Systemic Effects
+
+Describe:
+- persistent institutional mismatch
+- low-welfare equilibrium risk
+- reduced adaptive capacity
+
+Always:
+- preserve uncertainty framing
+- avoid deterministic predictions
+
+---
+
+# Escalation Constraints
+
+Do NOT:
+- imply fraud without evidence
+- predict collapse
+- claim certainty
+- present moral judgment as analysis
+
+Prefer:
+- probabilistic interpretation
+- systems analysis
+- behavioral framing


### PR DESCRIPTION
## Summary

Add reusable structural-risk narrative template.

Defines:
- high-risk narrative structure
- borrower-impact framing
- governance escalation language
- affordability intervention framing
- uncertainty-aware narrative constraints

This separates narrative logic from scoring logic and enables future narrative calibration.