### PR TITLE
fix: restore bank stage cap to 40%

### DIFF
--- a/src/js/core/scoring.js
+++ b/src/js/core/scoring.js
@@ -139,7 +139,7 @@
     bank.turquoise = 0.20 + amplified((incomeMomentum + (1 - povertyPressure) + diversifiedCredit) / 3, 2.1) * 2.6;
 
     normalizeAndCap(pop);
-    normalizeAndCap(bank, 45);
+    normalizeAndCap(bank);
     return{population:pop,bank};
   }
 


### PR DESCRIPTION
PR #122 changed normalizeAndCap(bank, 45) — restores correct cap of 40% per stage as defined in specs/architecture.md.