### PR TITLE
fix: pass impactIndex to generateRecommendations — issue #127

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -290,7 +290,9 @@
     const spiralPop=spiral.population;
     const spiralBank=spiral.bank;
     const bankDominant=stages.reduce((a,b)=>spiralBank[a]>spiralBank[b]?a:b);
-    const spiralRec=generateRecommendations({data:d,population:spiralPop,bank:spiralBank,bankD:bankDominant,icons:iconsUi,stages:tUi.stages});
+    const spiralImpact = typeof window.calculateImpact === 'function' ? window.calculateImpact(analysis) : null;
+    const spiralImpactIndex = spiralImpact && Number.isFinite(spiralImpact.impactIndex) ? spiralImpact.impactIndex : null;
+    const spiralRec=generateRecommendations({data:d,population:spiralPop,bank:spiralBank,bankD:bankDominant,icons:iconsUi,stages:tUi.stages,impact:{impactIndex:spiralImpactIndex}});
     initSpiralChart(spiralPop,spiralBank);
     renderDetailedAnalysis(d,spiralPop,spiralBank);
 


### PR DESCRIPTION
Computes impact before generateRecommendations call in refresh(). Tiered recommendations now fire correctly. Closes #127.