### PR TITLE
fix: decouple population branching from bank consumer-credit threshold (issue #142)

### DIFF
--- a/src/js/core/scoring.js
+++ b/src/js/core/scoring.js
@@ -57,34 +57,26 @@
     const pop={beige:0,purple:0,red:0,blue:0,orange:0,green:0,yellow:0,turquoise:0};
     const bank={beige:0,purple:0,red:0,blue:0,orange:0,green:0,yellow:0,turquoise:0};
 
-    if (safeData.cc > 40) {
-      pop.beige = 40;
-      pop.purple = Math.min(15, 15 - (safeData.gd / 300));
-      pop.red = 5;
-      pop.blue = 25;
-      pop.orange = Math.min(5, safeData.gd / 500);
-      pop.green = Math.min(15, (safeData.pr * 0.4) + 2);
-      pop.yellow = 0;
-      pop.turquoise = 0;
-    } else {
-      pop.beige = Math.min(30, safeData.pr * 1.2);
-      pop.purple = Math.min(25, 30 - (safeData.gd / 200));
-      pop.red = Math.min(35, 20 + safeData.pr * 0.4);
-      pop.blue = 33;
-      pop.orange = Math.min(25, safeData.gd / 150);
-      pop.green = Math.min(20, safeData.pr * 0.5);
-      pop.yellow = Math.min(15, safeData.ig > 10 ? 12 : 5);
-      pop.turquoise = 0;
-    }
+    const povertyPressure = scale(safeData.pr, 5, 45);
+    const developmentLevel = scale(safeData.gd, 900, 12000);
+    const incomeMomentum = scale(safeData.ig, 0, 25);
+    const consumerSegment = scale(safeData.cc, 15, 70);
+
+    pop.beige = 18 + povertyPressure * 22 - developmentLevel * 12;
+    pop.purple = 12 + povertyPressure * 10 - developmentLevel * 3;
+    pop.red = 8 + povertyPressure * 10 + consumerSegment * 6 - incomeMomentum * 5;
+    pop.blue = 24 + (1 - povertyPressure) * 10 + incomeMomentum * 5 + consumerSegment * 2;
+    pop.orange = 7 + developmentLevel * 16 + incomeMomentum * 4 - povertyPressure * 3 - consumerSegment * 3;
+    pop.green = 7 + incomeMomentum * 9 + (1 - povertyPressure) * 6 - consumerSegment * 2;
+    pop.yellow = 2 + developmentLevel * 5 + incomeMomentum * 3;
+    pop.turquoise = 0.5 + developmentLevel * 1.5 + incomeMomentum * 1.2;
 
     const profitGap = safeData.pg / Math.max(safeData.ig, 1);
     const interestSpread = Math.max(0, safeData.ix - safeData.im);
 
-    const consumerPressure = scale(safeData.cc, 15, 70);
+    const consumerPressure = consumerSegment;
     const businessFocus = scale(safeData.cb, 8, 60);
     const profitMomentum = scale(safeData.pg, 5, 220);
-    const incomeMomentum = scale(safeData.ig, 0, 25);
-    const povertyPressure = scale(safeData.pr, 5, 45);
     const spreadPressure = scale(interestSpread, 2, 22);
     const extractionGap = scale(profitGap, 1.5, 8);
     const capitalStrength = scale(safeData.cp, 8, 80);


### PR DESCRIPTION
### Motivation
- The prior population model used a binary `cc > 40` branch inside `calculateSpiralStages()` which produced divergent population profiles depending on a bank's consumer-credit concentration rather than macro indicators. 
- This caused inconsistent population stage outputs for banks in the same country (e.g., KICB vs peers) and made population modeling overly sensitive to bank-level product mix.

### Description
- Removed the binary `if (safeData.cc > 40)` branch and implemented a continuous, macro-driven population model inside `calculateSpiralStages()` in `src/js/core/scoring.js` using `povertyPressure`, `developmentLevel`, `incomeMomentum`, and `consumerSegment` signals. 
- Replaced the two-model approach with new baseline formulas that compute `pop.beige`, `pop.purple`, `pop.red`, `pop.blue`, `pop.orange`, `pop.green`, `pop.yellow`, and `pop.turquoise` from the macro signals and smooth `cc` influence. 
- Reused the normalized `consumerSegment` for downstream bank-stage calculations by assigning `const consumerPressure = consumerSegment;` to avoid duplicate scaling and keep calibration consistent. 
- Touched only `src/js/core/scoring.js` and preserved behavior and interfaces consumed by other engines and UI code.

### Testing
- Ran local Node checks invoking `calculateSpiralStages()` for demo inputs (Eldik, Optima, Demir, KICB, Bakai) and confirmed population outputs now share a common macro-driven base distribution with only small deltas. 
- Ran `calcScore()` together with `calculateSpiralStages()` and `calculateMismatch()` for the Eldik sample and verified `riskLevel` remains `high` and a numeric `mismatchScore` is produced. 
- All automated checks executed in the local environment completed successfully and produced consistent numeric outputs for the updated model.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ffcb2b4848324b2e23fd7d04a82c4)