### PR TITLE
feat: add hero demo layer (issue #55)

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,13 @@
     .lang-b{padding:7px 14px;border:none;background:transparent;border-radius:6px;cursor:pointer;font-weight:500;font-size:.9rem}
     .lang-b.a{background:var(--p);color:#fff}
     .input-s{background:var(--c);border-radius:12px;padding:18px;box-shadow:0 1px 3px rgba(0,0,0,.1);margin-bottom:16px}
+    .hero-demo{background:linear-gradient(135deg,#eff6ff 0%,#f8fafc 100%);border:1px solid #bfdbfe;border-radius:12px;padding:16px 18px;margin-bottom:16px;display:grid;gap:10px}
+    .hero-demo__badge{display:inline-flex;align-items:center;gap:8px;width:fit-content;padding:5px 10px;border-radius:999px;background:#dbeafe;color:#1e3a8a;font-size:.78rem;font-weight:700}
+    .hero-demo__title{font-size:1.25rem;font-weight:700;line-height:1.35}
+    .hero-demo__subtitle{font-size:.9rem;color:var(--tm);max-width:780px}
+    .hero-demo__actions{display:flex;flex-wrap:wrap;gap:8px}
+    .btn-ghost{padding:10px 14px;border:1px solid var(--b);border-radius:8px;background:#fff;color:var(--t);font-size:.86rem;font-weight:600;cursor:pointer}
+    .btn-ghost:hover{border-color:#93c5fd;background:#eff6ff}
     .input-h{display:flex;justify-content:space-between;align-items:center;margin-bottom:16px;flex-wrap:wrap;gap:10px}
     .sec-t{font-size:1.15rem;font-weight:600;display:flex;align-items:center;gap:8px}
     .sec-t::before{content:'';width:4px;height:16px;background:var(--p);border-radius:2px}
@@ -176,6 +183,16 @@
       <div class="logo"><div class="logo-i">BWA</div><span id="hTitle">Bank Welfare Analyzer</span></div>
       <div class="lang"><button class="lang-b a" id="btnRU" onclick="setLang('ru')">RU</button><button class="lang-b" id="btnEN" onclick="setLang('en')">EN</button></div>
     </header>
+
+    <section class="hero-demo" aria-live="polite">
+      <div class="hero-demo__badge" id="heroDemoBadge">🧪 Public Demo</div>
+      <h1 class="hero-demo__title" id="heroDemoTitle">Stress-test bank welfare assumptions before decisions.</h1>
+      <p class="hero-demo__subtitle" id="heroDemoSubtitle">This layer runs on public + estimated inputs. Use it for rapid orientation, then validate on internal data in Sponsor Lab.</p>
+      <div class="hero-demo__actions">
+        <button class="btn-p" type="button" id="heroDemoPrimary" onclick="loadEx('eldik')">Load demo bank</button>
+        <button class="btn-ghost" type="button" id="heroDemoSecondary" onclick="doAnalyze()">Run quick analysis</button>
+      </div>
+    </section>
 
     <section class="input-s">
       <div class="input-h">

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -2,6 +2,9 @@
   const tr = {
     ru: {
       app:"Bank Welfare Analyzer",inpTitle:"Ввод данных банка",btnAnalyze:"🚀 Анализировать",
+      heroDemoBadge:"🧪 Публичное демо",heroDemoTitle:"Проверьте welfare-гипотезы банка до принятия решений.",
+      heroDemoSubtitle:"Этот слой работает на публичных и оценочных данных. Используйте для быстрой ориентации, затем валидируйте на внутренних данных в Sponsor Lab.",
+      heroDemoPrimary:"Загрузить демо-банк",heroDemoSecondary:"Быстрый анализ",heroDemoContextPrefix:"Текущий демо-кейс",
       exLabel:"Примеры:",exEldik:"🏦 Eldik Bank",exOptima:"🏦 Optima Bank",exDemir:"🏦 Demir Bank",exKicb:"🏦 KICB",exBakai:"🏦 Bakai Bank",exNew:"✨ Новый банк",
       lName:"Название банка *",lCountry:"Страна",lProfit:"Рост прибыли (%) *",
       lCapital:"Капитализация",lDiv:"Дивиденды акционерам (%)",lIntMin:"Ставка мин (%)",lIntMax:"Ставка макс (%)",
@@ -138,6 +141,9 @@
     },
     en: {
       app:"Bank Welfare Analyzer",inpTitle:"Bank Input Data",btnAnalyze:"🚀 Analyze",
+      heroDemoBadge:"🧪 Public demo",heroDemoTitle:"Stress-test bank welfare assumptions before decisions.",
+      heroDemoSubtitle:"This layer runs on public + estimated inputs. Use it for rapid orientation, then validate on internal data in Sponsor Lab.",
+      heroDemoPrimary:"Load demo bank",heroDemoSecondary:"Run quick analysis",heroDemoContextPrefix:"Current demo case",
       exLabel:"Examples:",exEldik:"🏦 Eldik Bank",exOptima:"🏦 Optima Bank",exDemir:"🏦 Demir Bank",exKicb:"🏦 KICB",exBakai:"🏦 Bakai Bank",exNew:"✨ New bank",
       lName:"Bank Name *",lCountry:"Country",lProfit:"Profit Growth (%) *",
       lCapital:"Capitalization",lDiv:"Dividends to Shareholders (%)",lIntMin:"Min Rate (%)",lIntMax:"Max Rate (%)",

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -13,6 +13,18 @@
   function $(id){return document.getElementById(id);}
   function showRes(){$('resultsSection').style.display='block';}
   function hideRes(){$('resultsSection').style.display='none';}
+  function updateHero(data){
+    const t=window.i18n.tr[window.i18n.lang];
+    if($('heroDemoBadge')) $('heroDemoBadge').textContent=t.heroDemoBadge;
+    if($('heroDemoTitle')) $('heroDemoTitle').textContent=t.heroDemoTitle;
+    if($('heroDemoPrimary')) $('heroDemoPrimary').textContent=t.heroDemoPrimary;
+    if($('heroDemoSecondary')) $('heroDemoSecondary').textContent=t.heroDemoSecondary;
+    if($('heroDemoSubtitle')){
+      $('heroDemoSubtitle').textContent=(data&&data.bn)
+        ? `${t.heroDemoContextPrefix}: ${data.bn}. ${t.heroDemoSubtitle}`
+        : t.heroDemoSubtitle;
+    }
+  }
 
   function loadEx(n){
     exampleBtnIds.forEach(id=>{const el=$(id);if(el)el.classList.toggle('a',(id==='exEldik'&&n==='eldik')||(id==='exOptima'&&n==='optima')||(id==='exDemir'&&n==='demir')||(id==='exKicb'&&n==='kicb')||(id==='exBakai'&&n==='bakai')||(id==='exNew'&&n==='new'));});
@@ -142,6 +154,7 @@
     showRes();
     $('hTitle').textContent=`${d.bn} | ${window.i18n.tr[window.i18n.lang].app}`;
     refresh(d);
+    updateHero(d);
     localStorage.setItem('bwa_data',JSON.stringify(d));
     ($('execSummary')||$('resultsTitle')).scrollIntoView({behavior:'smooth',block:'start'});
   }
@@ -463,6 +476,7 @@
     if(sv){try{const d=JSON.parse(sv);const m={bn:'bankName',co:'country',pg:'profitGrowth',cp:'capital',di:'dividends',im:'interestMin',ix:'interestMax',ig:'incomeGrowth',pr:'povertyRate',gd:'gdpPerCapita',as:'avgSalary',cc:'creditConsumption',cb:'creditBusiness',co2:'creditOther'};Object.keys(d).forEach(k=>{if($(m[k])&&d[k]!==undefined)$(m[k]).value=d[k];});}catch(e){}}
     refresh(def);
     window.setLang('en');
+    updateHero(sv ? getData() : null);
     showRes();
     ['creditConsumption','creditBusiness','creditOther'].forEach(id=>$(id).addEventListener('change',fixCredit));
     if ($('rankInput')) {


### PR DESCRIPTION
### Motivation
- Surface a lightweight hero/demo layer that clarifies this build uses public/estimated inputs and offers quick CTAs to load a demo bank or run an analysis. 
- Keep existing UI behavior and i18n structure intact while limiting edits to the UI and localization layers.

### Description
- Added a hero/demo section to `index.html` that includes a badge, localized title/subtitle, primary CTA to load the demo bank, a secondary CTA to run a quick analysis, and supporting styles. 
- Added localized keys for RU/EN in `src/js/i18n.js`: `heroDemoBadge`, `heroDemoTitle`, `heroDemoSubtitle`, `heroDemoPrimary`, `heroDemoSecondary`, and `heroDemoContextPrefix`. 
- Implemented `updateHero(data)` in `src/js/ui.js` to populate localized hero texts, show a contextual subtitle after analysis, and initialize hero state on page load. 
- Touched only the allowed files: `index.html`, `src/js/ui.js`, and `src/js/i18n.js`, with no modifications to `src/js/core/*.js`.

### Testing
- Ran `git diff --check` to validate the patch format and whitespace, which reported no issues. 
- Verified via static inspection that only the specified files were changed and that localized strings are provided for both `ru` and `en`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1000b5d2c08324a2f789cc33fc6f33)